### PR TITLE
Fix to avoid networking manual interaction in slow DHCP when installing ubuntu

### DIFF
--- a/change-image/dell/barclamps/provisioner/chef/cookbooks/ubuntu-install/recipes/default.rb
+++ b/change-image/dell/barclamps/provisioner/chef/cookbooks/ubuntu-install/recipes/default.rb
@@ -79,7 +79,7 @@ end
     next
   # The nova_install case
   else
-    append_line="append crowbar.install.key=#{machine_install_key} #{serial_console} url=http://#{admin_ip}:#{web_port}/ubuntu_dvd/#{image}/net_seed debian-installer/locale=en_US.utf8 console-setup/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/choose_interface=auto netcfg/get_hostname=\"redundant\" initrd=../install/netboot/ubuntu-installer/amd64/initrd.gz ramdisk_size=16384 root=/dev/ram rw quiet --"
+    append_line="append crowbar.install.key=#{machine_install_key} #{serial_console} url=http://#{admin_ip}:#{web_port}/ubuntu_dvd/#{image}/net_seed debian-installer/locale=en_US.utf8 console-setup/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/dhcp_timeout=120 netcfg/choose_interface=auto netcfg/get_hostname=\"redundant\" initrd=../install/netboot/ubuntu-installer/amd64/initrd.gz ramdisk_size=16384 root=/dev/ram rw quiet --"
     
     template "#{install_path}/pxelinux.cfg/default" do
       mode 0644


### PR DESCRIPTION
Adding netcfg/dhcp_timeout=120 to append line, to force more than 120 seconds when installing ubuntu. Although in net_seed.erb is added, if is not added in the append line is not actually applied.
