### PR TITLE
Fixed a typo for the following issue:

### DIFF
--- a/ubuntu-10.10-extra/build_lib.sh
+++ b/ubuntu-10.10-extra/build_lib.sh
@@ -157,7 +157,7 @@ final_build_fixups() {
        (   cd scratch;
            debug "Adding all nic drivers"
            for udeb in "$IMAGE_DIR/pool/main/l/linux/"nic-*-generic-*.udeb; do
-               ar x "$udeb"
+               tar x "$udeb"
                tar xzf data.tar.gz
                rm -rf debian-binary *.tar.gz
            done 


### PR DESCRIPTION
/opt/crowbar/./ubuntu-10.10-extra/build_lib.sh: line 160: ar: command not found
tar (child): data.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
