### PR TITLE
Simplify code for pull-requests-gen and add a skeleton smoketest to the test barlcamp. [4/4]

### DIFF
--- a/build_crowbar.sh
+++ b/build_crowbar.sh
@@ -48,6 +48,9 @@ export PATH="$PATH:/sbin:/usr/sbin:/usr/local/sbin"
 [[ -f build-crowbar.conf ]] && \
     . "build-crowbar.conf"
 
+# Always run in verbose mode for now.  
+VERBOSE=true
+
 # Set up our proxies if we were asked to.
 if [[ $USE_PROXY = "1" && $PROXY_HOST ]]; then
     proxy_str="http://"

--- a/build_lib.sh
+++ b/build_lib.sh
@@ -629,7 +629,7 @@ barclamp_file_cache_needs_update() {
 die() { echo "$(date '+%F %T %z'): $*" >&2; res=1; exit 1; }
 
 # Print a message to stderr and keep going.
-debug() { echo "$(date '+%F %T %z'): $*" >&2; }
+debug() { [[ $VERBOSE ]] && echo "$(date '+%F %T %z'): $*" >&2; }
 
 # Clean up any cruft that we might have left behind from the last run.
 clean_dirs() {

--- a/dev
+++ b/dev
@@ -132,6 +132,17 @@ root_branches() {
     return 0
 }
 
+ordered_branches() {
+    # $@ = branches to print all of the children of.
+    [[ $@ ]] && local branches=("$@") || local branches=("$(root_branches)")
+    local b children=()
+    printf "%s\n" "${branches[@]}"
+    for b in "${branches[@]}"; do
+	children=($(child_branches "$b"))
+	[[ $children ]] && ordered_branches "${children[@]}"
+    done
+}
+
 # Given a branch, print the first remote that branch is "owned" by
 remote_for_branch() {
     local remote
@@ -143,6 +154,17 @@ remote_for_branch() {
     return 1
 }
 
+# Given a remote and a list of branches,
+# return just the branches that are in that remote.
+filter_branches_for_remote() {
+    local remote="$1" b
+    shift
+    for b in "$@"; do
+	is_in "${b##*/}" "${DEV_REMOTE_BRANCHES[$remote]}" || continue
+	echo "$b"
+    done
+}
+    
 # Test to see if a specific repository is clean.
 # Ignores submodules and unchecked-in directories that are git repositories.
 git_is_clean() {
@@ -223,17 +245,17 @@ barclamps_from_branch() {
     fi
     sort <(barclamps_in_branch "$1") <(barclamps_in_branch "$parent") |uniq -u
 }
-    
+
 # Fetch (but do not merge) updates from all our remotes, in both the
 # main Crowbar repository and the barclamps.
 fetch_all() {
     local remote barclamp b
     for remote in "${DEV_REMOTES[@]}"; do
-        [[ $VERBOSE ]] && echo "Fetching $remote"
+        debug "Fetching $remote"
 	in_repo git fetch "$remote" || continue
 	for b in ${DEV_REMOTE_BRANCHES[$remote]}; do
 	    for barclamp in $(barclamps_from_branch "${DEV_RELEASE_PREFIX}$b"); do
-		[[ $VERBOSE ]] && echo "Fetching $barclamp"
+		debug "Fetching $barclamp"
 		in_barclamp "$barclamp" git fetch origin || \
 		    die "Cound not fetch updates for $barclamp"
 	    done
@@ -510,12 +532,12 @@ sync_repo() (
 		echo "It should probably be on ${DEV_BRANCH_PREFIX}master, but you need to fix it."
 		return 1 
 	    }
-            [[ $VERBOSE ]] && echo "Checking out $branch"
+            debug "Checking out $branch"
 	    git checkout "$branch" || {
 		echo "$bc: Unable to checkout $branch!" >&2
 		return 1
 	    }
-            [[ $VERBOSE ]] && echo "Merging $origin/$branch into $branch"
+            debug "Merging $origin/$branch into $branch"
 	    git merge -q "$origin/$branch" || {
 		echo "$1: Unable to merge $origin/$branch into $branch, will unwind." >&2
 		git reset --hard
@@ -537,14 +559,14 @@ ripple_changes_out() {
     for child in $(child_branches "$parent"); do
 	in_repo git rev-parse --verify -q "$parent" &>/dev/null || \
 	    die "ripple_changes_out: $child is not a branch in Crowbar!"
-        [[ $VERBOSE ]] && echo "Testing $parent -> $child"
+        debug "Testing $parent -> $child"
 	remote_branches_synced "$CROWBAR_DIR" "refs/heads/$child" "refs/heads/$parent" && continue
 	[[ $head ]] || head=$(in_repo git symbolic-ref HEAD) || \
 	    die "Could not save the current branch!"
-        [[ $VERBOSE ]] && echo "Checking out $child"
+        debug "Checking out $child"
 	[[ $(in_repo git symbolic-ref HEAD) = refs/heads/$child ]] || \
 	    in_repo git checkout "$child"
-        [[ $VERBOSE ]] && echo "Merging $parent into $child"
+        debug "Merging $parent into $child"
 	in_repo git merge -q "$parent" || \
 	    die "Merge $parent into $child branch of Crowbar failed."
 	ripple_changes_out "$child"
@@ -561,12 +583,12 @@ sync_everything() {
 	die "Will not try to sync local repo with origin when working tree is dirty."
     # Do barclamps first.
     for b in $(barclamps_in_branch ${DEV_REMOTE_BRANCHES[@]}); do
-        [[ $VERBOSE ]] && echo "Syncing $b"
+        debug "Syncing $b"
 	sync_repo "$CROWBAR_DIR/barclamps/$b" && continue
 	unsynced_barclamps+=("$b")
     done
     # Finished with barclamps, now for crowbar.
-    [[ $VERBOSE ]] && echo "Syncing crowbar"
+    debug "Syncing crowbar"
     sync_repo "$CROWBAR_DIR" || \
 	die "Could not sync Crowbar with origin branches"
     # Now for the branch-rippling merges of doom
@@ -723,7 +745,7 @@ do_pull_request() {
     shift
     make_pull_request "$@" | \
     	curl -X POST --data @- -u "$DEV_GITHUB_ID:$DEV_GITHUB_PASSWD" \
-	-H "Content-Type: application/vnd.github.beta.raw+json" \
+    	-H "Content-Type: application/vnd.github.beta.raw+json" \
     	"$posturl"
 }
 
@@ -732,9 +754,20 @@ do_pull_request() {
 # pull_requests_prep generated.
 pull_requests_gen() {
     # $@ = options to parse
-    local -A barclamps pull_requests barclamp_branches branches refs
-    local bc br bcr title body option handled_branches=() bc_name head
-    local pull_request_count=0 n=1
+    local -A barclamps branches barclamp_branches bc_pulls br_pulls refs
+    local bc br bcr title body option bc_name head
+    local prc=0 n=1
+    echo "Enter a title for this pull request series."
+    echo "After you have entered a title, an editor will open, and you can"
+    echo "enter anything you want for the body of the pull requests."
+    read -p "Title: " title
+    body="$(mktemp /tmp/crowbar-pull-req-XXXXXXXX)"
+    if [[ $EDITOR ]]; then
+	$EDITOR "$body"
+    else
+	nano "$body"
+    fi
+    # Parse our options and validate them.
     while [[ "$1" ]]; do
 	case $1 in
 	    --branches) 
@@ -744,10 +777,7 @@ pull_requests_gen() {
 		    shift
 		    in_repo branch_exists "$br" || \
 			die "$br is not a branch in Crowbar!"
-		    [[ ${branches["$br"]} ]] || {
-			branches["$br"]="${DEV_BRANCHES["${br##*/}"]}"
-			pull_request_count=$((pull_request_count + 1))
-		    }
+		    branches["$br"]="true"
 		done;;
 	    --barclamps)
 		shift
@@ -761,112 +791,80 @@ pull_requests_gen() {
 			die "$br is not a branch in barclamp $bc!"
 		    [[ $br = *master ]] || \
 			die "Non-master branch for a barclamp passed.  Not valid for now."
-		    [[ ${barclamps["$bc"]} ]] || barclamps["$bc"]="unclassified"
-		    is_in "$br" "${barclamp_branches["$bc"]}" || {
+		    barclamps["$bc"]="true"
+		    is_in "$br" "${barclamp_branches["$bc"]}" || \
 			barclamp_branches["$bc"]+=" $br"
-			pull_request_count=$((pull_request_count + 1))
-		    }
 		done;;
 	    *) die "Unknown option $1 to $0 pull-requests-gen!";;
 	esac
     done
-    classify_barclamps
-    for bc in "${!barclamps[@]}"; do
-	br=${DEV_BRANCH_PREFIX}${barclamps["$bc"]}
-	[[ $br = "${DEV_BRANCH_PREFIX}unclassified" ]] && \
-	    die "pull_requests_gen: Encountered unclassified barclamp $bc."
-	[[ ${branches["$br"]} ]] || {
-	    branches["$br"]="${DEV_BRANCH_PREFIX}${DEV_BRANCHES["${br##*/}"]}"
-	    pull_request_count=$((pull_request_count + 1))
-	}
-    done
-    echo "Enter a title for this pull request series."
-    echo "After you have entered a title, an editor will open, and you can"
-    echo "enter anything you want for the body of the pull requests."
-    read -p "Title: " title
-    body="$(mktemp /tmp/crowbar-pull-req-XXXXXXXX)"
-    if [[ $EDITOR ]]; then
-	$EDITOR "$body"
-    else
-	nano "$body"
-    fi
-    
     # The logic here is:
     # Find the "most central" branch for the current set of pull reqs.
-    # Generate pull requests for branches on its barclamps next.
-    # Generate a pull request for that branch next.
-    # Find the next most central branch.
+    # Record that we need pull requests for each item we find.
     # lather, rinse, repeat until we are out of branches.
-    while [[ ${!branches[*]} ]]; do
-	for br in "${!branches[@]}"; do
-	    # If our parent branch is not ourself, or the hash for our 
-	    # parent is not unset, skip past this branch for now.
-	    if [[ ${DEV_BRANCH_PREFIX}${branches["$br"]} != \
-		$br && ${branches[${DEV_BRANCH_PREFIX}${branches[$br]}]} ]]
-	    then
-		continue
-	    fi
-	    local submodule_adds=()
-	    for bc in "${!barclamps[@]}"; do
-		[[ ${DEV_BRANCH_PREFIX}${barclamps["$bc"]} = $br ]] || continue
-		for bcr in ${barclamp_branches["$bc"]}; do
-                    bc_name=$(in_barclamp $bc git config --get remote.origin.url)
-                    bc_name=${bc_name##*/}
-                    bc_name=${bc_name##*:}
-                    bc_name=${bc_name%.git}
-		    do_pull_request "https://api.github.com/repos/dellcloudedge/$bc_name/pulls" \
-			--title "$title [$n/$pull_request_count]" \
-			--base "$bcr" \
-			--head "$DEV_GITHUB_ID:$(in_barclamp "$bc" git rev-parse "$bcr")" \
-			--body "@$body" \
-			--body "$(if in_barclamp "$bc" git rev-parse --verify -q "origin/$bcr" &>/dev/null; then in_barclamp "$bc" git diff --stat "origin/$bcr" $bcr; else echo "No origin to generate diffstat"; fi)" 
-		    n=$(($n + 1))
-		done
-		submodule_adds+=("$bc")
+
+    for br in $(filter_branches_for_remote origin $(ordered_branches)); do
+	for bc in $(barclamps_from_branch "$br"); do
+	    [[ ${barclamps[$bc]} ]] || continue
+	    for bcb in ${barclamp_branches["$bc"]}; do
+		bc_pulls["$bc/$bcb"]="true"
 	    done
-	    if [[ $submodule_adds ]]; then
-		# We need to update submodule references.  Therefore, a little
-		# trickery is required to make sure we don't wind up with
-		# weird add/add or update/update merge conflicts
+	    [[ ${refs["$br"]} ]] || \
+		refs["$br"]="$(in_repo git rev-parse --verify -q "refs/heads/$br")"
+	    if ! [[ $(in_repo git symbolic-ref HEAD) = "refs/heads/$br" ]]
+	    then
 		[[ $head ]] || head="$(in_repo git symbolic-ref HEAD)" || \
-		    die "pull-requests-gen: Need to push added submodules, but not on a branch!"
+		    die "pull-requests-gen: Crowbar not on a branch!"
 		in_repo git checkout "$br" || \
-		    die "pull-requests-gen: Could not checkout $branch"
-		# Save the current ref
-		ref["$branch"]="$(in_repo git rev-parse --verify -q HEAD)"
-		# Add updated barclamp references...
-		for sm in "${submodule_adds[@]}"; do
-		    in_repo git add "barclamps/$sm" || \
-			die "pull-requests-gen: Unable to update submodule reference for $sm"
-		done
-		# commit then...
-		in_repo git commit -m "Add updated submodule references for ${submodule_adds[@]}"
-		
-		# create a unique semi-meaningful throwaway branch name...
-		local refname="$(in_repo git describe --all --long --match "$br")"
-		refname=${refname//\//-}
-		# ... and push it to our personal github repo.
-		in_repo git push personal HEAD:"pull-req-$refname"
+		    die "pull-requests-gen: Could not checkout $br"
 	    fi
-		
-	    do_pull_request "https://api.github.com/repos/dellcloudedge/crowbar/pulls" \
-		--title "$title [$n/$pull_request_count]" \
-		--base "$br" \
-		--head "$DEV_GITHUB_ID:$(in_repo git rev-parse "$br")" \
-		--body "@$body" \
-		--body "$(if in_repo git rev-parse -q --verify origin/$br &>/dev/null; then git diff --stat origin/$br $br; else echo "No origin to generate diffstat."; fi)"
-	    n=$(($n + 1))
-	    # If we have a saved ref, then we updated some submodule refs.
-	    # We need to undo that locally so that we don't wind up conflicting
-	    # with ourselves.
-	    if [[ $ref ]]; then 
-		in_repo git reset --hard "$ref"
-		unset ref
-	    fi
-	    # We are done with this branch.  Unset its hash entry.
-	    unset branches["$br"]
-	    break
+	    in_repo git add "barclamps/$bc"
 	done
+	if [[ ${refs["$br"]} ]]; then
+	    in_repo git commit -m "Add updated submodule references for $br"
+	    local parent="$(parent_branch "$br")"
+	    [[ $parent ]] && in_repo git merge -q "$parent"
+	    local refname="$(in_repo git describe --all --long --match "$br")"
+	    refname=${refname//\//-}
+	    # ... and push it to our personal github repo.
+	    in_repo git push personal HEAD:"pull-req-$refname"
+	    br_pulls["$br"]="true"
+	fi
+	[[ ${branches["$br"]} ]] && br_pulls["$br"]=true
+    done
+    # OK, now we know how many pull requests we have to issue.
+    prc=$((${#bc_pulls[@]} + ${#br_pulls[@]}))
+
+    # issue the pull requests for our barclamps.
+    for barclamp in "${!bc_pulls[@]}"; do
+	local bc=${barclamp%%/*}
+	local bcb=${barclamp#*/}
+	local bc_name=$(in_barclamp $bc git config --get remote.origin.url)
+        bc_name=${bc_name##*/}
+        bc_name=${bc_name##*:}
+        bc_name=${bc_name%.git}
+	do_pull_request "https://api.github.com/repos/dellcloudedge/$bc_name/pulls" \
+	    --title "$title [$n/$prc]" --base "$bcr" \
+	    --head "$DEV_GITHUB_ID:$(in_barclamp "$bc" git rev-parse "$bcb")" \
+	    --body "@$body" \
+	    --body "$(if in_barclamp "$bc" git rev-parse --verify -q "origin/$bcr" &>/dev/null; then in_barclamp "$bc" git diff --stat "origin/$bcb" $bcb; else echo "No origin to generate diffstat"; fi)" 
+	n=$(($n + 1))
+    done
+
+    # Now, issue the requests for branches. 
+    # Make sure they are ordered correctly.
+    for br in $(filter_branches_for_remote origin $(ordered_branches)); do
+	[[ ${br_pulls["$br"]} ]] || continue
+	do_pull_request "https://api.github.com/repos/dellcloudedge/crowbar/pulls" \
+	    --title "$title [$n/$prc]" --base "$br" \
+	    --head "$DEV_GITHUB_ID:$(in_repo git rev-parse "$br")" \
+	    --body "@$body" \
+	    --body "$(if in_repo git rev-parse -q --verify origin/$br &>/dev/null; then git diff --stat origin/$br $br; else echo "No origin to generate diffstat."; fi)"
+	n=$(($n + 1))
+	if [[ ${refs["$br"]} ]]; then
+	    git checkout "$br"
+	    git reset --hard "${refs[$br]}"
+	fi
     done
     [[ $head ]] && in_repo git checkout "${head#refs/heads/}"
     rm -f "$body"


### PR DESCRIPTION
Two main changes:

Make the code in pull-requests-prep and pull-requests-gen easier to 
understand via the use of a few new helper functions.

Add a skeleton smoketest to the test barclamp for teaching purposes.

 build_crowbar.sh |    3 +
 build_lib.sh     |    2 +-
 dev              |  317 +++++++++++++++++++++++++++---------------------------
 3 files changed, 164 insertions(+), 158 deletions(-)
