### PR TITLE
Have dev manage release branches in the build cache. [3/3]

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -131,10 +131,11 @@ get_barclamp_info() {
     done
 }
 
-
 [[ $CROWBAR_BUILD_PID ]] || export CROWBAR_BUILD_PID=$$
 export CLEANUP_LOCK="$CROWBAR_DIR/.cleanup.lock"
 cleanup_cmds=()
+
+git_managed_cache() [[ -d $CACHE_DIR/.git ]]
 
 # Our general cleanup function.  It is called as a trap whenever the
 # build script exits, and it's job is to make sure we leave the local
@@ -662,7 +663,6 @@ get_rev() (
 
 # Run a git command in the build cache, assuming it is a git repository.
 in_cache() (
-    [[ $CURRENT_CACHE_BRANCH ]] || return
     cd "$CACHE_DIR"
     "$@"
 )

--- a/dev
+++ b/dev
@@ -1187,6 +1187,13 @@ cut_release() {
     for b in $barclamps; do
         in_barclamp "$b" git branch ${new_prefix}master ${this_prefix}master
     done
+    if git_managed_cache && ! branch_exists "${new_prefix}master"; then
+        if in_cache branch_exists "${this_prefix}master"; then
+            in_cache git branch "${new_prefix}master" "${this_prefix}master"
+        else
+            in_cache git branch "${new_prefix}master" master
+        fi
+    fi
 }
 
 # Check out the appropriate release branch for all the barclamps in a given
@@ -1225,6 +1232,10 @@ switch_release() {
         done
     done
     in_repo git checkout -q "${new_base}${current_branch}"
+    if git_managed_cache && in_cache branch_exists "${new_base}master"; then
+        debug "Checking out ${new_base}master in the build cache, please be patient."
+        in_cache git checkout -qf "${new_base}master"
+    fi
 }
 
 case $1 in


### PR DESCRIPTION
this pull request adds support for the dev tool to manage the build cache
as part of its internal release management process. 

 build_lib.sh |    4 ++--
 dev          |   11 +++++++++++
 2 files changed, 13 insertions(+), 2 deletions(-)
