### PR TITLE
Fixed typo in dev instructions [2/3]

### DIFF
--- a/README.dev-and-workflow
+++ b/README.dev-and-workflow
@@ -2,7 +2,7 @@ This file documents dev, the workflow helper tool for Crowbar
 development.
 
 dev is designed to help automate the workflow and infrastructure
-related tasks associated with devopment in general with the Crowbar
+related tasks associated with development in general with the Crowbar
 git tree layout.  Dev is designed around the following assumptions:
 
  * Everyone has their own forks on Github of the Crowbar repository


### PR DESCRIPTION
Test pull request that fixes a typo in the dev tool instructions.

 README.dev-and-workflow |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
