### PR TITLE
Fix typo in teamed network proposal [1/1]

### DIFF
--- a/network-openstack-team.json
+++ b/network-openstack-team.json
@@ -108,7 +108,7 @@
 	 }
         },
         {
-	 "pattern": "team/.*/ .*",
+	 "pattern": "team/.*/.*",
 	 "conduit_list": { 
 	   "intf0": {
 	     "if_list": [ "1g1", "1g2" ],


### PR DESCRIPTION
1 character fix ;) remove extra space from regexp in teamed proposal

 network-openstack-team.json |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
