### PR TITLE
Fixes for "dev setup" [2/4]

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -216,6 +216,7 @@ cleanup() {
     # If we saved unadded changes, resurrect them.
     [[ $THROWAWAY_STASH ]] && git stash apply "$THROWAWAY_STASH" &>/dev/null
     # Do the same thing as above, but for the build cache instead.
+    mkdir -p "$CACHE_DIR"
     cd "$CACHE_DIR"
     if ! in_cache git diff-index --cached --quiet HEAD; then
         in_cache git commit -m "Updated by build_crowbar.sh @ $(date) for ${OS_TOKEN}"

--- a/dev
+++ b/dev
@@ -351,6 +351,7 @@ switch_barclamps_to() {
     for bc in "$CROWBAR_DIR/barclamps/"*; do
         [[ -d $bc/.git || -f $bc/.git ]] || \
             clone_barclamp "${bc##*/}"
+        in_barclamp "${bc##*/}" git fetch
         bc="${bc#$CROWBAR_DIR/}"
         if [[ ${barclamps[$bc]} && ${barclamps[$bc]} = refs/heads/* ]]; then
             head=$(in_barclamp "${bc##*/}" git symbolic-ref HEAD)
@@ -617,8 +618,8 @@ setup() {
             echo "Unable to authenticate as Github user $DEV_GITHUB_ID." >&2
             die "Please try again when you have Github access."
         }
-        echo "DEV_GITHUB_ID=\'$DEV_GITHUB_ID\'" >> "$HOME/.build-crowbar.conf"
-        echo "DEV_GITHUB_PASSWD=\'$DEV_GITHUB_PASSWD\'" >> \
+        printf "DEV_GITHUB_ID=%q\n" "$DEV_GITHUB_ID" >> "$HOME/.build-crowbar.conf"
+        printf "DEV_GITHUB_PASSWD=%q\n" "$DEV_GITHUB_PASSWD" >> \
             "$HOME/.build-crowbar.conf"
     }
     # We have a baked-in assumption that Github is our origin, and that


### PR DESCRIPTION
Following
https://github.com/dellcloudedge/crowbar/wiki/Dev-tool-build
I tried to run "./dev setup" but it would fail on misquoting the
GitHub credentials and on having outdated barclamp clones.

Also included is a trivial fix to initially create CACHE_DIR

 build_lib.sh |    1 +
 dev          |    5 +++--
 2 files changed, 4 insertions(+), 2 deletions(-)
