### PR TITLE
Have dev use ~/.netrc to store Github authentication instead of juggling raw passwords. [1/4]

### DIFF
--- a/dev
+++ b/dev
@@ -76,6 +76,18 @@ export CROWBAR_DIR
 . "$CROWBAR_DIR/build_lib.sh" || exit 1
 trap - 0 INT QUIT TERM
 
+if [[ $DEV_GITHUB_PASSWD ]]; then
+    debug "Migrating Github password information to $HOME/.netrc"
+    for mach in github.com api.github.com; do
+	grep -q "^$mach" "$HOME/.netrc" &>/dev/null && continue
+	printf "\nmachine %s login %s password %s\n" \
+	    "$mach" "$DEV_GITHUB_ID" "$DEV_GITHUB_PASSWD" >> "$HOME/.netrc"
+    done
+    chmod 600 "$HOME/.netrc"
+    sed -ie 's/DEV_GITHUB_PASSWD=.*//' "$HOME/.build-crowbar.conf"
+    debug "Please remove your embedded login information from the remote URLS."
+fi
+
 which gem &>/dev/null || \
     die "Rubygems not installed, and some of our helpers need a JSON gem."
 


### PR DESCRIPTION
This feature migrates us away from doing our own password management
by embedding Github username/password authentication into our curl calls
and remote URL strings.  Instead, we add entries for github.com and
api.github.com to the user's .netrc file, fix up all the direct curl
calls we make to ensure they know to look in .netrc for authorization info,
and rely on Git doing the same thing when it has to talk http.

The benefit to doing all this is that we no longer have to worry about
passwords that have special characters in them, nor do we spam auth info
all over the barclamps -- instead, it is in one place that all the tools 
know how to access and that is a little more securable.
