### PR TITLE
Update the dev tool to make feature bundles more flexible and to allow resetting a release or feature. [1/4]

### DIFF
--- a/dev
+++ b/dev
@@ -2058,9 +2058,15 @@ reset_release() {
                 esac;;
             *) die "Don't know how to reset to $target_method";;
         esac
-        in_repo git rev-parse --quiet --verify \
-            "${branches[$br]}" &>/dev/null || \
-            die "Cannot reset $br to ${branches[$br]}"
+        if ! in_repo git rev-parse --quiet --verify \
+            "${branches[$br]}" &>/dev/null; then
+            if [[ $target = backup ]]; then
+                debug "$br has never been backed up, skipping."
+                unset branches[$br]
+            elif [[ $target = upstream ]]; then
+                die "Cannot reset $br to ${branches[$br]}"
+            fi
+        fi
         [[ $skip_barclamps = true ]] && continue
         for bc in $(barclamps_from_branch "$br"); do
             [[ ${barclamps[$bc]} ]] && continue
@@ -2079,9 +2085,15 @@ reset_release() {
                     esac;;
                 *) die "Don't know how to reset barclamp $bc to $target_method";;
             esac
-            in_barclamp "$bc" git rev-parse --quiet --verify \
-                "${barclamp_targets[$bc]}" &>/dev/null || \
-                die "Cannot reset barclamp $bc to ${barclamp_targets[$bc]}"
+            if ! in_barclamp "$bc" git rev-parse --quiet --verify \
+                "${barclamp_targets[$bc]}" &>/dev/null; then
+                if [[ $target = backup ]]; then
+                    debug "${barclamps[$bc]} in $bc has never been backed up, skipping."
+                    unset barclamps[$bc]
+                elif [[ $target = upstream ]]; then
+                    die "Cannot reset barclamp $bc to ${barclamp_targets[$bc]}"
+                fi
+            fi
         done
     done
     for bc in "${!barclamps[@]}"; do


### PR DESCRIPTION
1: Make feature bundles more general.
   You can now make a feature off any release insstead of just off the
   development release.  This makes it much more generally
   applicable.  To compliment this new functionality, the dev tool has
   grown the ability to figure out what release a feature was forked
   from, and generating a pull request for a feature bundle will
   arragnge for it to be merged into its origin.
2: Add a command to reset a release or feature to its last backup or
   the state that the upstream repository is in.

 dev |  299 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-------
 1 files changed, 267 insertions(+), 32 deletions(-)
