### PR TITLE
dev: support cloning crowbar etc. into github organizations [3/4]

### DIFF
--- a/dev
+++ b/dev
@@ -718,6 +718,10 @@ setup() {
 	chmod 600 "$HOME/.netrc"
         echo "DEV_GITHUB_ID='$DEV_GITHUB_ID'" >> "$HOME/.build-crowbar.conf"
     }
+    # Force remote origin to canonical dellcloudedge repo (in case we're
+    # operating out of a clone from another org, in which case fetch would
+    # be against that other org):
+    in_repo git remote set-url origin "$(github_url crowbar.git)"
     # We have a baked-in assumption that Github is our origin, and that
     # any repositories that are named the same thing as a repository from
     # dellcloudedge is in fact a fork of a dellcloudedge repo.


### PR DESCRIPTION
If DEV_GITHUB_ORG is set in ~/.build-crowbar.conf _instead_of_
DEV_GITHUB_ID, and you've got ~/.netrc with your regular github
credentials, you can work off a clone of the dellcloudedge
repo in a github organization, rather than in a person repo.
This means that the so-called "personal" remotes don't point to
your individual github repo, rather they point to the repos in
the org you're working out of.

Usage:

1) Make sure your ~/.netrc and ~/.build-crowbar.conf files look like this:
# cat ~/.netrc

machine github.com login YOUR_GH_USERNAME password YOUR_GH_PASSWORD
machine api.github.com login YOUR_GH_USERNAME password YOUR_GH_PASSWORD
# cat ~/.build-crowbar.conf

DEV_GITHUB_ORG='YOUR_GH_ORG'

2) Clone the crowbar repo from https://github.com/dellcloudedge/crowbar.git

3) Run crowbar/dev setup

This will create missing forks etc. in your organization.

Note that if DEV_GITHUB_ORG is set and you are using "dev backup" to push
your local changes to github, this will no longer do a force push (which
would otherwise stomp on other people's changes), so if "dev backup" fails
to push some refs, run "dev fetch" and "dev sync" first.

 dev |   54 +++++++++++++++++++++++++++++++++++++++++++++++++-----
 1 files changed, 49 insertions(+), 5 deletions(-)
