### PR TITLE
Include Broadcom NetXtreme II NIC firmware drivers on the installer initrd (attempt 2) [1/4]

### DIFF
--- a/ubuntu-common/build_lib.sh
+++ b/ubuntu-common/build_lib.sh
@@ -189,6 +189,10 @@ final_build_fixups() {
             tar xzf data.tar.gz
             rm -rf debian-binary *.tar.gz
         done 
+        # bnx2x nic drivers require firmware images from the kernel image .deb
+        ar x "$IMAGE_DIR/pool/main/l/linux/"linux-image-*-generic_*.deb
+        tar xjf data.tar.bz2 --wildcards './lib/firmware/*/bnx2x/*'
+        rm -rf debian-binary control.tar.gz data.tar.bz2
         # Make sure installing off a USB connected DVD will work
         debug "Adding USB connected DVD support"
         mkdir -p var/lib/dpkg/info
@@ -205,7 +209,7 @@ final_build_fixups() {
 	    [[ -f $IMAGE_DIR/$initrd ]] || continue
 	    mkdir -p "$BUILD_DIR/${initrd%/*}"
 	    gunzip -c "$IMAGE_DIR/$initrd" >"$BUILD_DIR/initrd.tmp"
-	    find . -type f | \
+	    find . | \
 		cpio --format newc --owner root:root \
 		-oAF "$BUILD_DIR/initrd.tmp"
 	    cat "$BUILD_DIR/initrd.tmp" | \


### PR DESCRIPTION
Modified the build script to extract the necessary firmware image files for
the Broadcom NetXtreme II NIC to the Ubuntu installer's initrd image.
Without this, during the os-install phase, the Ubuntu installer would
recognize the interfaces, but won't be able to obtain an DHCP lease
complaining about the missing files.

The fix is similar to the existing nic driver extraction code, but these
images are bundled with the kernel image deb.
