### PR TITLE
fixed conflicting packages caching in ubuntu-common/build_lib.sh

### DIFF
--- a/ubuntu-common/build_lib.sh
+++ b/ubuntu-common/build_lib.sh
@@ -41,9 +41,12 @@ chroot_install() {
 
 # Fetch (but do not install) packages into the chroot environment
 chroot_fetch() {
+    local pkg
     if [[ $1 ]]; then
-	in_chroot /usr/bin/apt-get -y --force-yes \
-	    --allow-unauthenticated --download-only install "$@"
+	for pkg in $@; do
+	    in_chroot /usr/bin/apt-get -y --force-yes \
+		--allow-unauthenticated --download-only install "$pkg"
+	done
     fi
     in_chroot /usr/bin/apt-get -y --force-yes \
 	--allow-unauthenticated --download-only upgrade


### PR DESCRIPTION
If the packages barclamp needs are already in cache, ISO will be built without any problems. BUT if the barclamp pkg cache is empty, then build script will try to fetch 
required packages using apt package manager in chroot environment. Then fetched packages will be copied into barclamp cache. The problem is that if there is any problem while attempting to fetch (for example in the case of conflicting packages), the packages will not be installed into chroot and will not be copied into cache and build process will not be failed.  It is because the command used to fetch is 

apt-get -y --force-yes --allow-unauthenticated --download-only install package1 package2

and if package1 conflicts with package2, these packages both will not be installed in spite on --download-only option. It could be avoided using two different commands instead of just common one. 

apt-get -y --force-yes --allow-unauthenticated --download-only install package1
apt-get -y --force-yes --allow-unauthenticated --download-only install package2
