### PR TITLE
Fixed typo [1/4]

### DIFF
--- a/redhat-common/build_lib.sh
+++ b/redhat-common/build_lib.sh
@@ -31,7 +31,7 @@ chroot_fetch() {
     local p
     for p in "$@"; do
         in_chroot /usr/bin/yum -y --downloadonly install "$p" || :
-    fi
+    done
     in_chroot /usr/bin/yum -y update
 }
 


### PR DESCRIPTION
Fixed typo on RHEL build script

 redhat-common/build_lib.sh |    2 +-
 1 files changed, 1 insertions(+), 1 deletions(-)
