### PR TITLE
Fix up Nova barclamp to pull in the ubuntu-virt repo. [5/5]

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -520,7 +520,7 @@ update_barclamp_pkg_cache() {
             [[ -d $bc_cache/${pkg%/*} ]] || mkdir -p "$bc_cache/${pkg%/*}"
             [[ -f $bc_cache/${pkg##*/} ]] && cache_rm "$bc_cache/${pkg##*/}"
         fi
-        cache_add "$CHROOT/$CHROOT_PKGDIR/$pkg" "$bc_cache/$pkg"
+        cache_add "$CHROOT/$CHROOT_PKGDIR/$pkg" "$bc_cache/${pkg//%3a/:}"
     done < <(cd "$CHROOT/$CHROOT_PKGDIR"; find -type f)
     local force_update=true
     update_barclamp_src_pkg_cache "$1"

--- a/ubuntu-common/build_lib.sh
+++ b/ubuntu-common/build_lib.sh
@@ -22,7 +22,7 @@ fetch_os_iso() {
     echo "$(date '+%F %T %z'): Downloading and caching $ISO"
     curl -o "$ISO_LIBRARY/$ISO" \
         "$ISO_MIRROR/ubuntu-iso/CDs/$OS_VERSION/$ISO" || \
-        die 1 "Missing our source image"
+        die "Missing our source image.  Please install $ISO in $ISO_LIBRARY."
 }
 
 # Have the chroot update its package databases.


### PR DESCRIPTION
See title.

This also adds a to de-URLencode cached file names, which was causing nginx
to break in certian rare occasions.

 build_lib.sh               |    2 +-
 ubuntu-common/build_lib.sh |    2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
