### PR TITLE
Make rsyslog not discard errors [1/1]

### DIFF
--- a/releases/development/master/extra/install-chef.sh
+++ b/releases/development/master/extra/install-chef.sh
@@ -140,7 +140,14 @@ update_hostname || die "Could not update our hostname"
 # When it does not, things get hard to debug pretty quick.
 (ip link set eth0 up; ip addr add 192.168.124.10/24 dev eth0 ) &>/dev/null || :
 
-# once our hostname is correct, bounce rsyslog to let it know.
+# Set up rsyslog to not rate limit to avoid discarding exceptions
+cat > /etc/rsyslog.d/10-noratelimit.conf <<EOF
+# Turn off rate limiting to prevent error discarding
+\$ModLoad imuxsock
+\$SystemLogRateLimitInterval 0
+EOF
+
+# Bounce rsyslog to let it know our hostname is correct and not to rate limit
 log_to svc service rsyslog restart || :
 
 # Link the discovery image to an off-DVD location.


### PR DESCRIPTION
Since the default configuration for rsyslog is to rate limit the messages,
errors can be discarded during install time or during normal execution
of crowbar.

This change makes rsyslog not rate limit so that errors will never be
discarded.

 releases/development/master/extra/install-chef.sh |    9 ++++++++-
 1 files changed, 8 insertions(+), 1 deletions(-)
