### PR TITLE
Rework unit tests to make the nicer-er.

### DIFF
--- a/dev
+++ b/dev
@@ -2352,9 +2352,8 @@ reload_unit_tests() (
 )
 
 run_unit_tests() (
-    if unit_tests_need_reset; then
-        setup_unit_tests || exit 1
-    elif [[ ! -f $CROWBAR_TEST_DIR/crowbar_framework/db/test.sqlite3 ]]; then
+    unit_tests_need_reset && clear_unit_tests
+    if [[ ! -f $CROWBAR_TEST_DIR/crowbar_framework/db/test.sqlite3 ]]; then
         reload_unit_tests || exit 1
     fi
     # Run unit tests


### PR DESCRIPTION
- Fail fast if our package prereqs are not met.
- Make run-unit-tests smart enough to run reload-unit-tests and setup-unit-tests if needed.
- Ditto for reload-unit-tests.
- Make run-unit-tests and reload-unit-tests aware of what build they are on, and automatically call setup-unit-tests if you have changed to s different build.
- Be much smarter about only pulling the proper barclamps for a build when installing barclamps for unit tests.
- Allow the location of the unit tests to be tweaked with CROWBAR_TEST_DIR
- Die quickly if a barclamp installation fails.
