### PR TITLE
Fix node allocating during smoketest

### DIFF
--- a/test_lib.sh
+++ b/test_lib.sh
@@ -982,6 +982,10 @@ deploy_nodes() {
                     smoketest_update_status "$node" "$res"
                     smoketest_update_status "$node" "Node deployed."
                     exit 0
+                elif res=$(check_ready "${hname/d/h}"); then
+                    smoketest_update_status "$node" "$res"
+                    smoketest_update_status "$node" "Node deployed."
+                    exit 0
                 elif [[ $lastres != $res ]]; then
                     smoketest_update_status "$node" "$res"
                     lastres="$res"


### PR DESCRIPTION
for unknown reason it polls status only from nodes with fqdn started with 'd'. So If it starts with 'h' the smoketest run be failed. That ugly workaround fixes the issue.
