### PR TITLE
dev tool ask for root password every time

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -267,7 +267,7 @@ cleanup() {
     wait
     flock -u 70
     rm "$CROWBAR_DIR/".*.lock
-    [[ -d $CROWBAR_TMP ]] && sudo rm -rf "$CROWBAR_TMP"
+    [[ -d $CROWBAR_TMP ]] && rm -rf "$CROWBAR_TMP"
     exit $res
 } 70> "$CLEANUP_LOCK"
 

--- a/dev
+++ b/dev
@@ -53,7 +53,7 @@ export CROWBAR_DIR
 
 . "$CROWBAR_DIR/build_lib.sh" || exit 1
 trap - 0 INT QUIT TERM
-trap 'sudo rm -rf "$CROWBAR_TMP"' 0 INT QUIT TERM
+trap 'rm -rf "$CROWBAR_TMP"' 0 INT QUIT TERM
 which gem &>/dev/null || \
     die "Rubygems not installed, and some of our helpers need a JSON gem."
 


### PR DESCRIPTION
Since a few days the dev tool is asking for the root password with every run. The root cause of this seems to be the:

trap 'sudo rm -rf "$CROWBAR_TMP"' 0 INT QUIT TERM

which was introduced with commit bdfc1c5. I wonder why that rm needs to be called with root privileges as I didn't find anything creating files below $CROWBAR_TMP that are not owned by the user calling "dev". I might have overlooked something though. But then it is still very much unexpected to be asked for the root password without any reason given by the tool.
