### PR TITLE
Don't assume that markdown is installed in /usr/bin

### DIFF
--- a/dev
+++ b/dev
@@ -2958,7 +2958,7 @@ purge_submodule_metadata() (
 unit_prereqs_installed() {
     local f gem
     f=true
-    if ! [[ -f /usr/bin/markdown ]]; then
+    if ! command -v markdown >/dev/null 2>&1; then
         debug "Please make sure markdown is installed."
         f=false
     fi


### PR DESCRIPTION
It's installed in different places depending on how you do it. For example, with rvm it is at:

```
/usr/local/rvm/gems/ruby-1.8.7-p371/bin/markdown
```

With gems it is at:

```
/usr/local/bin/markdown
```
