### PR TITLE
ignore reloadable directories if they don't exist in the source BC

### DIFF
--- a/dev
+++ b/dev
@@ -3224,6 +3224,7 @@ databases_need_reload() {
     for bc in "${barclamps[@]}"; do
         for p in "crowbar_framework/db" "crowbar_framework/test/fixtures" \
             "chef/data_bags"; do
+            [[ -d "$CROWBAR_DIR/barclamps/$1/$p" ]] || continue # ignore if dir not there.
             paths_same "$CROWBAR_TEST_DIR/barclamps/$1/$p" \
                 "$CROWBAR_DIR/barclamps/$1/$p" && continue
             debug "Database files changed in $bc, need reload."


### PR DESCRIPTION
e.g. - barclamp chef doesn'ht have test/fixtures... don't require the directory to exist for reload-unit-tests to work
