### PR TITLE
Get rid of annoying error message

### DIFF
--- a/parse_yml.rb
+++ b/parse_yml.rb
@@ -4,7 +4,7 @@ require 'yaml'
 # This is very cheesy, and should only be called by the build script.
 tree = YAML.load_file ARGV[0]
 ARGV[1..-1].each do |n|
-  tree = tree[n]
+  tree = tree[n] unless tree.nil?
 end
 case tree.class
 when Array


### PR DESCRIPTION
The following error message appears multiple times when running
`./dev setup-unit-tests --update-gem-cache`:

```
  crowbar/./parse_yml.rb:7: undefined method `[]' for nil:NilClass (NoMethodError)
    from crowbar/./parse_yml.rb:6:in `each'
    from crowbar/./parse_yml.rb:6
```

This patch prevents that.
