### PR TITLE
[Ruby 1.9] Fix requires

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -21,7 +21,7 @@
 if File.exists?('/opt/dell/bin/barclamp_mgmt_lib.rb')
   require '/opt/dell/bin/barclamp_mgmt_lib.rb'
 else
-  require 'barclamp_mgmt_lib.rb'
+  require File.join(File.dirname(__FILE__), 'barclamp_mgmt_lib.rb')
 end
 require 'getoptlong'
 require 'pp'


### PR DESCRIPTION
Ruby 1.9 does not automatically include the current directory in the
load path, so we need to provide the directory path as well.
