### PR TITLE
[SUSE] Fix group ownership for SUSE (openSUSE & SLE)

### DIFF
--- a/dev
+++ b/dev
@@ -3308,7 +3308,11 @@ reinstall_barclamps() {
         ./barclamp_install.rb --force --no-files --no-chef -b \
             "$CROWBAR_TEST_DIR" "${barclamp_list[@]}") || \
             die "Failed to install some barclamps."
-    sudo chown -R "$USER.$USER" "${CROWBAR_TEST_DIR}"
+
+    local group=$USER
+    [ -f /etc/SuSE-release ] && group=users
+    sudo chown -R "$USER.$group" "${CROWBAR_TEST_DIR}"
+
     find "$CROWBAR_TEST_DIR" -type d -exec chmod a+x '{}' ';'
     # Clean up the filelists.
     rm barclamps/*.txt


### PR DESCRIPTION
SUSE systems (openSUSE and SUSE Linux Enterprise) do not create a group
for each user. It uses a general 'users' group.

Without this patch, SUSE users will get an error message like the
following when running `./dev setup-unit-tests`:

```
chown: invalid user: 'jamestyj.jamestyj'
```
