### PR TITLE
[Dev setup] Handle dev setup dependencies in Gemfile

### DIFF
--- a/dev
+++ b/dev
@@ -3330,7 +3330,6 @@ unit_tests_need_reset() {
 setup_unit_tests() (
     local gem f bc barclamps=()
     local gem_offline=true update_gem_cache=false use_gem_cache=true
-    unit_prereqs_installed || exit 1
     for f in "$@"; do
         case $f in
             --update-gem-cache) update_gem_cache=true;;
@@ -3338,6 +3337,18 @@ setup_unit_tests() (
             *) barclamps+=("$f");;
         esac
     done
+    if [[ $use_gem_cache = true ]]; then
+        unit_prereqs_installed || exit 1
+    else
+        if command -v bundle >/dev/null 2>&1; then
+            debug "** Installing minimal dev setup dependencies..."
+            bundle install --gemfile=dev-setup/Gemfile
+            [ $? -eq 0 ] || die "Failed to install gem dependencies"
+            debug
+        else
+            die "Please make sure bundler is installed. Eg. 'sudo gem install bundler'"
+        fi
+    fi
     rm -rf "$CROWBAR_TEST_DIR"
     mkdir "$CROWBAR_TEST_DIR"
     reinstall_barclamps "${barclamps[@]}" || exit 1

--- a/dev-setup/Gemfile
+++ b/dev-setup/Gemfile
@@ -1,0 +1,19 @@
+# Copyright 2013, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Minimal set of gems required to run `./dev setup-unit-tests`.
+
+source 'https://rubygems.org'
+
+gem 'kwalify'
+gem 'builder'


### PR DESCRIPTION
Instead of checking that the required gem dependencies are present and
prompting the user to install it manually if not, specify what we need
in a Gemfile and let bundler take care of it.

This Gemfile should be very small and contain only the depedencies of
./dev setup-unit-tests. Everything else is pulled in by the main
Crowbar Gemfile.

It code path is only triggered when the --no-gem-cache option is given,
so it does not conflict with the existing gem cache mode for no Internet
use cases.
