### PR TITLE
Epic rename of cmdb to jig, for real this time. [7/7]

### DIFF
--- a/doc/devguide/api/attrib.md
+++ b/doc/devguide/api/attrib.md
@@ -1,6 +1,6 @@
 ### Attribute (aka Attrib) APIs
 
-Attribute APIs are used to manage attributes tracked by the CMDB system
+Attribute APIs are used to manage attributes tracked by the Jig system
 
 > To prevent Rails name collisions, Crowbar uses 'Attrib' instead of Attribute.
 

--- a/doc/devguide/api/jig.md
+++ b/doc/devguide/api/jig.md
@@ -1,25 +1,25 @@
-### CMDB APIs
+### Jig APIs
 
-CMDB APIs are used to manage configuration management databases.  
+Jig APIs are used to manage configuration management databases.  
 
-> WARNING: You cannot simply add a new CMDB type via the API!  CMDB object types must have a matching cmdb class override!  The primary function of this API is to manage the related CMDB subobjects.  You can have multiple CMDBs of the same type.
+> WARNING: You cannot simply add a new Jig type via the API!  Jig object types must have a matching jig class override!  The primary function of this API is to manage the related Jig subobjects.  You can have multiple Jigs of the same type.
 
-#### CMDB CRUD
+#### Jig CRUD
 
-List, Create, Read, Delete actions for CMDBs
+List, Create, Read, Delete actions for Jigs
 
 > There is no update at this time!
 
 ##### List
 
-Returns list of CMDB id:names in the system
+Returns list of Jig id:names in the system
 
 **Input:**
 
 <table border=1>
 <tr><th> Verb </th><th> URL </th><th> Options </th><th> Returns </th><th> Comments </th></tr>
 <tr><td> GET  </td>
-  <td> /2.0/crowbar/2.0/cmdb </td>
+  <td> /2.0/crowbar/2.0/jig </td>
   <td> - </td>
   <td> - </td></tr>
 </table>
@@ -35,8 +35,8 @@ Returns list of CMDB id:names in the system
 
 Details:
 
-* id - CMDB id
-* name - CMDB name
+* id - Jig id
+* name - Jig name
 
 ##### Read
 
@@ -45,8 +45,8 @@ Details:
 <table border=1>
 <tr><th> Verb </th><th> URL </th><th> Options </th><th> Returns </th><th> Comments </th></tr>
 <tr><td> GET  </td>
-  <td> /2.0/crowbar/2.0/cmdb/[id] </td>
-  <td> id is the cmdb ID or name. </td>
+  <td> /2.0/crowbar/2.0/jig/[id] </td>
+  <td> id is the jig ID or name. </td>
   <td> -  </td></tr>
 </table>
 
@@ -58,7 +58,7 @@ Details:
       "name":"chef",
       "description":null,
       "order":10000,
-      "type":"CmdbChef",
+      "type":"JigChef",
       "created_at":"2012-08-13T17:20:21Z",
       "updated_at":"2012-08-13T17:20:21Z"
     }
@@ -66,21 +66,21 @@ Details:
 Details:
 
 * Format - json
-* id - CMDB id
-* name - CMDB name
+* id - Jig id
+* name - Jig name
 * all Node properties serialized
 
-##### CMDB CRUD: Create
+##### Jig CRUD: Create
 
-Creates a new CMDB
+Creates a new Jig
 
 **Input:**
 
 <table border=1>
 <tr><th> Verb </th><th> URL </th><th> Options </th><th> Returns </th><th> Comments </th></tr>
 <tr><td> POST  </td>
-  <td> /2.0/crowbar/2.0/cmdb/ </td>
-  <td> json definition (see CMDB Show) </td>
+  <td> /2.0/crowbar/2.0/jig/ </td>
+  <td> json definition (see Jig Show) </td>
   <td> must be a legal object </td></tr>
 </table>
 
@@ -90,28 +90,28 @@ Creates a new CMDB
       "name":"chef",
       "description":"description",
       "order":10000,
-      "type":"CmdbChef"
+      "type":"JigChef"
     }
 
 Details:
 
-* name (required) - CMDB name (must be letters - numbers and start with a letter)
+* name (required) - Jig name (must be letters - numbers and start with a letter)
 * description - optional (default null)
-* type (required) - name of the object that manages the CMDB calls
+* type (required) - name of the object that manages the Jig calls
 * order - optional (default 10000) 
 
 > The type must match an existing class in the system
 
-##### CMDB CRUD: Delete 
+##### Jig CRUD: Delete 
 
-Deletes a CMDB
+Deletes a Jig
 
 **Input:**
 
 <table border=1>
 <tr><th> Verb </th><th> URL </th><th> Options </th><th> Returns </th><th> Comments </th></tr>
 <tr><td> DELETE  </td>
-  <td> /2.0/crowbar/2.0/cmdb/[id] </td>
+  <td> /2.0/crowbar/2.0/jig/[id] </td>
   <td> Database ID or name </td>
   <td> must be an existing object ID </td></tr>
 </table>
@@ -124,7 +124,7 @@ None.
 
 Details:
 
-* id - CMDB name or database ID
+* id - Jig name or database ID
 
 
 

--- a/doc/devguide/api/node.md
+++ b/doc/devguide/api/node.md
@@ -107,7 +107,7 @@ Details:
 
 Node Attributes API is used to retrieve data about attributes that have been associated with a Node.
 
-Typically, attribute data is populated by the CMDB system(s) based on the associations established using this API.
+Typically, attribute data is populated by the Jig system(s) based on the associations established using this API.
 
 #### Associations
 

--- a/doc/devguide/barclamps/metadata.md
+++ b/doc/devguide/barclamps/metadata.md
@@ -19,7 +19,7 @@ This migration is used to populate (or update) the barclamp information used by 
 * layout - version of layout (default 2)
 * order - display order in UI (default 0)
 * run_order
-* cmdb_order
+* jig_order
 * commit - automatically generated flag
 * build_on - automatically generated flag
   

--- a/doc/devguide/testing/bdd.md
+++ b/doc/devguide/testing/bdd.md
@@ -53,8 +53,8 @@ The Crowbar barclamp tests include:
 * scaffolds.feature - Tests all the feature objects
 * authenticate.feature - Tests login
 * users.feature - Tests user management screen
-* attributes - Tests CMDB attributes API
-* cmdbs - Tests the CMDB engine API
+* attributes - Tests Jig attributes API
+* jigs - Tests the Jig engine API
     
 
 ### Test Debugging

--- a/doc/devguide/testing/bdd/steps_rest.md
+++ b/doc/devguide/testing/bdd/steps_rest.md
@@ -21,10 +21,10 @@ Put commonly used string and information here.  This function is provided to hel
 
     g(Item) ->
       case Item of
-        path -> "2.0/crowbar/2.0/cmdb";
-        type -> "CmdbTest";
-        name1 -> "bddcmdb";
-        atom1 -> cmdb1;
+        path -> "2.0/crowbar/2.0/jig";
+        type -> "JigTest";
+        name1 -> "bddjig";
+        atom1 -> jig1;
         _ -> crowbar:g(Item)
       end.
 
@@ -58,7 +58,7 @@ The inspector is part of a housekeeping system for BDD that helps detect orphane
 The objective of the inspector method is to return a list of items found in the system.  This list is generated before and after BDD runs.
 
     inspector(Config) -> 
-      crowbar_rest:inspector(Config, cmdbs).  % shared inspector works here, but may not always
+      crowbar_rest:inspector(Config, jigs).  % shared inspector works here, but may not always
 
 > It is likely that you can leverage a generic inspector routine if your API has a consistent list pattern.
 
@@ -87,59 +87,59 @@ Common steps are easy to create because thy can leverage existing steps with min
 
 Get List 
 
-    step(Config, _Given, {step_when, _N, ["REST gets the cmdb list"]}) -> 
+    step(Config, _Given, {step_when, _N, ["REST gets the jig list"]}) -> 
       bdd_restrat:step(Config, _Given, {step_when, _N, ["REST requests the",eurl:path(g(path),""),"page"]});
 
 Get Object
 
-    step(Config, _Given, {step_when, _N, ["REST gets the cmdb",Name]}) -> 
+    step(Config, _Given, {step_when, _N, ["REST gets the jig",Name]}) -> 
       bdd_restrat:step(Config, _Given, {step_when, _N, ["REST requests the",eurl:path(g(path),Name),"page"]});
 
 Validate Object
 
 > This routine will call back the the modules own validate!
 
-    step(_Config, Result, {step_then, _N, ["the cmdb is properly formatted"]}) -> 
-      crowbar_rest:step(_Config, Result, {step_then, _N, ["the", cmdb, "object is properly formatted"]});
+    step(_Config, Result, {step_then, _N, ["the jig is properly formatted"]}) -> 
+      crowbar_rest:step(_Config, Result, {step_then, _N, ["the", jig, "object is properly formatted"]});
 
 
 Create Object
 
 >Creates a new object using the require components.  The routine builds the JSON for the object (see above) and then calls the shared create method.
 
-    step(Config, _Global, {step_given, _N, ["there is a cmdb",CMDB,"of type", Type]}) -> 
-      JSON = json(CMDB, g(description), Type, 200),
+    step(Config, _Global, {step_given, _N, ["there is a jig",Jig,"of type", Type]}) -> 
+      JSON = json(Jig, g(description), Type, 200),
       crowbar_rest:create(Config, g(path), JSON);
 
 Remove Object
 
-    step(Config, _Given, {step_finally, _N, ["REST removes the cmdb",CMDB]}) -> 
-      crowbar_rest:destroy(Config, g(path), CMDB);
+    step(Config, _Given, {step_finally, _N, ["REST removes the jig",Jig]}) -> 
+      crowbar_rest:destroy(Config, g(path), Jig);
 
 #### Reference Features
 
-    Scenario: CMDB List
-      Given there is a cmdb "my_special_cmdb"
-      When REST gets the cmdb list
-      Then there should be a value "my_special_cmdb"
+    Scenario: Jig List
+      Given there is a jig "my_special_jig"
+      When REST gets the jig list
+      Then there should be a value "my_special_jig"
         And there should be a value "chef"
-        And there should be a value "bddcmdb"
-      Finally REST removes the cmdb "my_special_cmdb"
+        And there should be a value "bddjig"
+      Finally REST removes the jig "my_special_jig"
   
     Scenario: REST JSON check
-      Given there is a cmdb "cmdb_json_test"
-      When REST gets the cmdb "cmdb_json_test"
-      Then the cmdb is properly formatted
-      Finally REST removes the cmdb "cmdb_json_test"
+      Given there is a jig "jig_json_test"
+      When REST gets the jig "jig_json_test"
+      Then the jig is properly formatted
+      Finally REST removes the jig "jig_json_test"
   
     Scenario: REST Add 
-      Given there is not a cmdb "cmdb_add_test"
-      When REST adds the cmdb "cmdb_add_test"
-      Then there is a cmdb "cmdb_add_test"
-      Finally REST removes the cmdb "cmdb_add_test"
+      Given there is not a jig "jig_add_test"
+      When REST adds the jig "jig_add_test"
+      Then there is a jig "jig_add_test"
+      Finally REST removes the jig "jig_add_test"
   
     Scenario: REST Delete 
-      Given there is a cmdb "cmdb_delete_test"
-      When REST deletes the cmdb "cmdb_delete_test"
-      Then there is a not cmdb "cmdb_delete_test"
+      Given there is a jig "jig_delete_test"
+      When REST deletes the jig "jig_delete_test"
+      Then there is a not jig "jig_delete_test"
 


### PR DESCRIPTION
This pull request series renames cmdb to jig across the entire Crowbar
codebase.

You can replicate its effects if you get a merge conflict with the
following commands:

cd barclamps
for bc in _; do
    (   cd "$bc" || continue
        git checkout master)
done
cd ..
while read -r f; do
    sed -i -e 's/cmdb/jig/g' -e 's/CMDB/Jig/g' -e 's/Cmdb/Jig/g' "$f"
    (   cd "${f%/_}"
        git add "${f##_/}")
done < <(grep --binary-files=without-match -irl cmdb \* |grep -v '.git')
while read f; do
    (   cd "${f%/_}"
        file="${f##_/}"
        git mv "$file" "${file//cmdb/jig}")
done < <(find -type f -name '_cmdb*' |grep -v '/.git/')
git commit -m "Epic rename of cmdb to jig"
cd barclamps
for bc in *; do
    (   cd "$bc" || continue
        git commit -m "Epic rename of cmdb to jig");
done
cd ..

 doc/devguide/api/attrib.md             |    2 +-
 doc/devguide/api/cmdb.md               |  130 --------------------------------
 doc/devguide/api/jig.md                |  130 ++++++++++++++++++++++++++++++++
 doc/devguide/api/node.md               |    2 +-
 doc/devguide/barclamps/metadata.md     |    2 +-
 doc/devguide/testing/bdd.md            |    4 +-
 doc/devguide/testing/bdd/steps_rest.md |   60 +++++++--------
 7 files changed, 165 insertions(+), 165 deletions(-)

Crowbar-Pull-ID: ca715c91ecfe7b42a192c575f9a6289aeb4c9007

Crowbar-Release: development
