### PR TITLE
Small tweak to order top level docs

### DIFF
--- a/doc/framework.yml
+++ b/doc/framework.yml
@@ -3,3 +3,24 @@ license: Apache 2
 copyright: "2013 by Dell, Inc"
 author: Dell CloudEdge Team
 date: "January 13, 2013"
+
+framework/gettingstarted:
+  order: 100
+
+framework/releasenotes:
+  order: 500
+  
+framework/userguide:
+  order: 1000
+
+framework/barclamps:
+  order: 2500
+    
+framework/deployguide:
+  order: 5000
+    
+framework/devguide:
+  order: 6000
+
+framework/licenses:
+  order: 99999


### PR DESCRIPTION
I cleaned up this file, but forgot to update it in the Crowbar root.

This overrides the alpha order of the docs root index.
