### PR TITLE
Fixed creation of "1" file [1/1]

### DIFF
--- a/releases/development/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/development/master/extra/barclamp_mgmt_lib.rb
@@ -262,7 +262,7 @@ def bc_do_install_action(bc,bc_path, stage)
   debug("actions to perform: #{actions.join(' ')}")
   actions.each { |action| 
     fatal("action #{action} not found for #{bc}") unless File.exists?(action)
-    output = `#{action} 2>1`
+    output = `#{action} 2>&1`
     fatal("action #{action} failed for #{bc}:\n #{output}") unless $? == 0
   }   
 end


### PR DESCRIPTION
A typo causes an empty releases/development/master/extra/1 file to be created when running dev setup-unit-tests.

This pull corrects the typo.

 .../development/master/extra/barclamp_mgmt_lib.rb  |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 09f8a0ca404551734712cc86a550f0a063946ea4

Crowbar-Release: development
