### PR TITLE
Fix the .* bug [1/1]

### DIFF
--- a/releases/fred/cloudera-build/network-hadoop-noteam-admin.json
+++ b/releases/fred/cloudera-build/network-hadoop-noteam-admin.json
@@ -60,7 +60,7 @@
        "pattern": "team/.*/crowbar-config-default",
        "conduit_list": { 
         "prod": {
-           "if_list": [ "1g2" ]
+           "if_list": [ "1g2","1g3" ]
          },
             "public": {
               "if_list": [ "1g1" ]


### PR DESCRIPTION
Fixing the added .\* by removing them.

 build_crowbar.sh                                   |   26 +-
 build_lib.sh                                       |   10 +-
 build_sledgehammer.sh                              |   16 +-
 dev                                                |   35 +-
 fetch_all_gems.rb                                  |    2 -
 package_barclamp.sh                                |   92 +---
 packaging/deb/debian/README                        |    6 -
 packaging/deb/debian/compat                        |    1 -
 packaging/deb/debian/control.erb                   |   17 -
 packaging/deb/debian/copyright                     |   66 ---
 packaging/deb/debian/dirs                          |    2 -
 packaging/deb/debian/rules.erb                     |   30 -
 packaging/make-pkg                                 |  124 -----
 packaging/rpm/crowbar-barclamp.spec.erb            |   70 ---
 .../development/master/extra/barclamp_install.rb   |   46 +-
 .../development/master/extra/barclamp_mgmt_lib.rb  |   52 +--
 .../network-hadoop-noteam-admin.json               |    2 +-
 releases/v2.1-hadoop-dell/master/change-image      |    1 +
 .../master/change-image/dell/check_ready           |   70 ---
 .../master/change-image/dell/knife_node_find       |    5 -
 .../master/change-image/dell/name_to_ip            |   14 -
 .../master/change-image/dell/parse_node_data       |   89 ---
 .../master/change-image/dell/parse_yml_or_json     |   57 --
 .../master/change-image/dell/run_on                |    4 -
 .../master/change-image/dell/smoketest             |  225 --------
 .../master/change-image/dell/update_hostname.sh    |   41 --
 releases/v2.1-hadoop-dell/master/extra             |    1 +
 .../master/extra/barclamp_create.rb                |   65 ---
 .../master/extra/barclamp_install.rb               |  187 -------
 .../master/extra/barclamp_mgmt_lib.rb              |  564 --------------------
 .../master/extra/barclamp_uninstall.rb             |   46 --
 .../v2.1-hadoop-dell/master/extra/chef-client.pill |    8 -
 .../v2.1-hadoop-dell/master/extra/chef-server.conf |   44 --
 .../v2.1-hadoop-dell/master/extra/chef-server.pill |   64 ---
 releases/v2.1-hadoop-dell/master/extra/h2n.tar.gz  |  Bin 188554 -> 0 bytes
 .../v2.1-hadoop-dell/master/extra/index.html.tmpl  |   12 -
 .../v2.1-hadoop-dell/master/extra/install-chef.sh  |  470 ----------------
 .../master/extra/patches/command.rb.patch          |   19 -
 .../master/extra/patches/data_item.rb.patch        |   29 -
 .../v2.1-hadoop-dell/master/extra/patches/patch.sh |   30 -
 .../master/extra/patches/platform.rb.patch         |   19 -
 .../master/extra/patches/rubygems.rb.2.patch       |   75 ---
 .../master/extra/patches/rubygems.rb.patch         |   75 ---
 .../master/extra/patches/run_list.rb.patch         |   19 -
 .../master/extra/patches/unix.rb.patch             |   20 -
 .../master/extra/redhat-common-post.sh             |  114 ----
 .../master/extra/rubygems-server.pill              |   11 -
 suse-common/rpm-building/seed-barclamp-packages.rb |    7 +-
 .../rpm-building/templates/barclamp_service.erb    |   10 +-
 .../templates/crowbar-barclamp.spec.erb            |   46 +--
 travis-ci/README.md                                |    6 +-
 travis-ci/update-git.sh                            |   15 +-
 52 files changed, 132 insertions(+), 2927 deletions(-)

Crowbar-Pull-ID: b747cfffacc9ac6a0f542d0202cd44c7fb150557

Crowbar-Release: fred
