### PR TITLE
barclamp_install: Fix bc_do_install_action (missing parameter) [1/1]

### DIFF
--- a/releases/development/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/development/master/extra/barclamp_mgmt_lib.rb
@@ -76,7 +76,7 @@ def bc_install(bc, bc_path, yaml)
     debug "Installing cache components" unless @@no_files
     bc_install_layout_1_cache bc, bc_path unless @@no_files
     debug "Performing install actions" unless @@no_install_actions
-    bc_do_install_action bc, :install unless @@no_install_actions
+    bc_do_install_action bc, bc_path, :install unless @@no_install_actions
   else
     throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
@@ -256,7 +256,7 @@ end
 # The crowbar reserves the ranges 0-9 and 50-9.
 # Other params:
 #   bc - the barclamps name
-def bc_do_install_action(bc, stage)
+def bc_do_install_action(bc, bc_path, stage)
   setup_target = File.join(@SETUP_PATH,bc)
   suffix = ""
   case stage


### PR DESCRIPTION
 releases/development/master/extra/barclamp_mgmt_lib.rb | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: aa6607c6b66c9eb41f15471b9ad47ba1b1a14f0c

Crowbar-Release: development
