### PR TITLE
Update ./dev setup-unit-tests to include /doc directory

### DIFF
--- a/dev
+++ b/dev
@@ -3981,7 +3981,11 @@ setup_unit_tests() (
         "run the unit tests may not be the same as the ones used to build and"\
         "install Crowbar, so results may differ."
     fi
-
+    
+    mkdir -p "$CROWBAR_TEST_DIR/doc/framework"
+    echo "Copying base docs from $CROWBAR_DIR/doc/. to $CROWBAR_TEST_DIR/opt/dell/doc/framework"
+    cp -r "$CROWBAR_DIR/doc/." "$CROWBAR_TEST_DIR/opt/dell/doc/framework"
+            
     cd "$CROWBAR_TEST_DIR/opt/dell/BDD"
     sudo "$CROWBAR_TEST_DIR/opt/dell/BDD/linux_install.sh"
     ./linux_compile.sh


### PR DESCRIPTION
This copy was omitted in the refactoring and was causing the BDD tests to fail.

The added lines will copy the doc into doc/framework as required by the doc system
