### PR TITLE
change uses of throw to raise

### DIFF
--- a/releases/feature/folsom/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/feature/folsom/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/feature/grizzly/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/feature/grizzly/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/feature/inbound-data/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/feature/inbound-data/master/extra/barclamp_mgmt_lib.rb
@@ -62,7 +62,7 @@ end
 def bc_install(bc, bc_path, yaml)
   case yaml["crowbar"]["layout"].to_s
   when "1"
-    throw "ERROR: Crowbar 1.x barclamp formats are not supported in Crowbar 2.x"
+    raise "ERROR: Crowbar 1.x barclamp formats are not supported in Crowbar 2.x"
   when "1.9","2"
     debug "Installing app components"
     bc_install_layout_2_app bc, bc_path, yaml
@@ -73,7 +73,7 @@ def bc_install(bc, bc_path, yaml)
     debug "Performing install actions"
     bc_do_install_action bc, bc_path, :install
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog bc_path
 end

--- a/releases/feature/pfs-folsom/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/feature/pfs-folsom/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/feature/report-handler/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/feature/report-handler/master/extra/barclamp_mgmt_lib.rb
@@ -65,7 +65,7 @@ end
 def bc_install(bc, bc_path, yaml)
   case yaml["crowbar"]["layout"].to_s
   when "1"
-    throw "ERROR: Crowbar 1.x barclamp formats (#{bc}) are not supported in Crowbar 2.x"
+    raise "ERROR: Crowbar 1.x barclamp formats (#{bc}) are not supported in Crowbar 2.x"
   when "1.9","2"
     debug "Installing app components"
     bc_install_layout_2_app bc, bc_path, yaml unless @@deploy
@@ -78,7 +78,7 @@ def bc_install(bc, bc_path, yaml)
     debug "Performing install actions" unless @@no_install_actions
     bc_do_install_action bc, bc_path, :install unless @@no_install_actions
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog bc_path
 end

--- a/releases/hadoop-2.1/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/hadoop-2.1/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/v2.0-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/v2.0-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
@@ -54,7 +54,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/v2.0-hadoop/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/v2.0-hadoop/master/extra/barclamp_mgmt_lib.rb
@@ -54,7 +54,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/v2.1-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/v2.1-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/v2.1-hadoop/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/v2.1-hadoop/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end

--- a/releases/v2.1.1-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/v2.1.1-hadoop-dell/master/extra/barclamp_mgmt_lib.rb
@@ -55,7 +55,7 @@ def bc_install(bc, path, barclamp, options={})
     puts "DEBUG: Installing cache components" if debug
     bc_install_layout_1_cache bc, path, barclamp, :debug => debug
   else
-    throw "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
+    raise "ERROR: could not install barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."
   end
   catalog path, :debug => debug
 end


### PR DESCRIPTION
'throw' is for escaping from control flow, whereas 'raise' is for
error conditions, e.g.

http://rubylearning.com/blog/2011/07/12/throw-catch-raise-rescue-im-so-confused/
