### PR TITLE
switch kiwi appliance to use systemsmanagement:crowbar:2.0:staging OBS p...

### DIFF
--- a/opensuse-12.2-extra/kiwi-appliance/source/config.xml
+++ b/opensuse-12.2-extra/kiwi-appliance/source/config.xml
@@ -96,4 +96,7 @@
   <repository type='rpm-md'>
     <source path='http://download.opensuse.org/repositories/systemsmanagement:crowbar:2.0/openSUSE_12.2/'/>
   </repository>
+  <repository type='rpm-md'>
+    <source path='http://download.opensuse.org/repositories/systemsmanagement:crowbar:2.0:staging/openSUSE_12.2/'/>
+  </repository>
 </image>


### PR DESCRIPTION
...roject

Since this appliance is primarily for development, it makes more sense
to consume packages from the systemsmanagement:crowbar:2.0:staging OBS
project first, and from systemsmanagement:crowbar:2.0 second.
