### PR TITLE
Get admin node deploy working-ish again, and fix a few nits. [5/5]

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -150,7 +150,6 @@ class BarclampFS
           FileUtils.mkdir_p(File.join(target,"crowbar_framework/test/unit"))
           FileUtils.cp_r(File.join(dir,ent,"barclamp_"+@name+"/test/unit"),File.join(target,"crowbar_framework/test/"))
         end
-        next if skip_engines 
         debug("#{@name} is implemented using a Rails Engine.")
         debug("Linking in routes and Gemfile entries.")
         gem_name       = "barclamp_#{@name}"
@@ -167,10 +166,8 @@ class BarclampFS
         FileUtils.mkdir_p(gemfile_dir)
         routes_plugin  = File.join(routes_dir,  "barclamp-#{@name}-engine.routes")
         gemfile_plugin = File.join(gemfile_dir, "barclamp-#{@name}.gemfile")
-        File.new(routes_plugin,  'w').puts \
-          "mount #{engine_class}, :at => '#{@name}'"
-        File.new(gemfile_plugin, 'w').puts \
-          "gem '#{gem_name}', :path => File.join(crowbar_path, '..', 'barclamps', '#{@name}', '#{engine_path}')"
+        File.new(routes_plugin,  'w').puts("mount #{engine_class}, :at => '#{@name}'") unless File.exists?(routes_plugin)
+        File.new(gemfile_plugin, 'w').puts("gem '#{gem_name}', :path => File.join(crowbar_path, '..', 'barclamps', '#{@name}', '#{engine_path}')") unless File.exists?(gemfile_plugin)
       when 'bin'
         debug("Installing commands for #{@name}")
         FileUtils.mkdir_p(File.join(target,'bin'))


### PR DESCRIPTION
This pull request does the following:
- Create an admin node record in the Crowbar databases by default
  when the crowbar barclamp is initialized.
- Tweak barclamp_install to add the engine fragments to the master
  framework at package build time instead of install time. This
  leverages the engine cleanup that Adam added.
- Fix a bug in CSS/SASS handling in engines that the previous change
  exposed. Engines need their own application.sass instead of
  application.css if they expose any sass fragments, and the do not
  seem to require their own application.css at all.
  
  .../development/master/extra/barclamp_install.rb   |    7 ++-----
  1 file changed, 2 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: b315146a56209cc5b6a07cb05124133c40dca602

Crowbar-Release: development
