### PR TITLE
dev: run_unit_tests(): don't mix include directories

### DIFF
--- a/dev
+++ b/dev
@@ -4056,11 +4056,10 @@ run_unit_tests() (
         test_runner=(
             rcov
             --aggregate coverage/testing.data
-            -Ispec:lib:test
             --exclude /gems/,/Library/,/usr/,lib/tasks,.bundle,/config/,/lib/rspec/,/lib/rspec-,spec
         )
-        spec_runner=( "${test_runner[@]}" spec/*/*.rb    )
-        unit_runner=( "${test_runner[@]}" test/unit/*.rb )
+        spec_runner=( "${test_runner[@]}" -Ispec:lib spec/*/*.rb    )
+        unit_runner=( "${test_runner[@]}" -Itest:lib test/unit/*.rb )
     else
         spec_runner=( rake spec )
         unit_runner=( rake test )


### PR DESCRIPTION
There's a small chance of rspec-only libraries or test-unit-only
libraries messing up the other framework, so it's worth avoiding
the risk since it's easy to do so.  This only affects Ruby 1.8.
