### PR TITLE
Minor install tweaks [2/2]

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -173,6 +173,10 @@ class BarclampFS
         FileUtils.mkdir_p(File.join(target,'bin'))
         FileUtils.cp_r(File.join(@source,'bin'),target)
         FileUtils.chmod_R(0755,File.join(target,'bin'))
+      when 'etc'
+        debug("Installing configs for #{@name}")
+        FileUtils.mkdir_p(File.join(@root,'etc'))
+        FileUtils.cp_r(File.join(@source,'etc'),@root)
       when 'updates'
         debug("Installing Sledgehammer updates for #{@name}")
         FileUtils.mkdir_p(File.join(@root,'updates'))


### PR DESCRIPTION
This pull request contains
- barclamp_install can now install stuff into /etc if barclamps contain a etc
  directory
- Extracted the crowbar init script the setup action and install it as a
  separte file
- cleaned up the crowbar init script, to make it a little less ugly. And
  added LSB Headers to it
  
  releases/development/master/extra/barclamp_install.rb | 4 ++++
  1 file changed, 4 insertions(+)

Crowbar-Pull-ID: c8601de183a0126162e53e4cc84bf648d1a9e211

Crowbar-Release: development
