### PR TITLE
Don't pollute the global gem cache with gems for the crowbar framework [2/2]

### DIFF
--- a/releases/development/master/extra/install-crowbar-native.sh
+++ b/releases/development/master/extra/install-crowbar-native.sh
@@ -52,7 +52,10 @@ export FQDN="$1"
 export DEBUG=true
 
 if [[ $OS != suse ]]; then
-    export PATH="/opt/dell/bin:/usr/local/bin:$PATH"
+    [[ $PATH != */opt/dell/bin* ]] || export PATH="$PATH:/opt/dell/bin"
+    if [[ -f /etc/environment ]] && ! grep -q '/opt/dell/bin' /etc/environment; then
+        sed -i -e "/^PATH/ s@\"\(.*\)\"@\"$PATH\"@" /etc/environment 
+    fi
     [[ ! $HOME || $HOME = / ]] && export HOME="/root"
     mkdir -p "$HOME"
 


### PR DESCRIPTION
This pull requests does two things:
- Install crowbar framework gems with bundle install --path vendor/bundle instead of just using bundle install.  This keeps bundler inadvertently interfering with external commands that might use different versions of the gems the framework requires.
- Fix up /etc/environment handling to not mangle the path quite as much.  Since we no longer have duplicate knife and chef-client commands lying around, we no longer need to mess with $PATH in an attempt to make sure the right one gets used.
  
  .../master/extra/install-crowbar-native.sh         |    5 ++++-
  1 file changed, 4 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 94c0227ddb31f0e37eda928591c5b68de4dc9b4d

Crowbar-Release: development
