### PR TITLE
Remove network-test-helper.rb from crowbar barclamp and copy it in from network barclamp [1/1]

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -150,6 +150,9 @@ class BarclampFS
           FileUtils.mkdir_p(File.join(target,"crowbar_framework/test/unit"))
           FileUtils.cp_r(File.join(dir,ent,"barclamp_"+@name+"/test/unit"),File.join(target,"crowbar_framework/test/"))
         end
+        if FileTest.exists?(File.join(dir,ent,"barclamp_"+@name+"/test/"+@name+"_test_helper.rb"))
+          FileUtils.cp(File.join(dir,ent,"barclamp_"+@name+"/test/"+@name+"_test_helper.rb"),File.join(target,"crowbar_framework/test/"))
+        end
         debug("#{@name} is implemented using a Rails Engine.")
         debug("Linking in routes and Gemfile entries.")
         gem_name       = "barclamp_#{@name}"


### PR DESCRIPTION
Remove network-test-helper.rb from crowbar barclamp and copy it in from network barclamp

 .../development/master/extra/barclamp_install.rb   |    3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: 35aa62cadaf64b8ab439ba96ac2cb598a9c35856

Crowbar-Release: development
