### PR TITLE
Fix file ownership issues during install [2/2]

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -144,6 +144,9 @@ class BarclampFS
         next if use_engine || skip_files
         debug("Copying crowbar_framework files over for #{@name}")
         FileUtils.cp_r(File.join(@source,'crowbar_framework'),target)
+        # The rake tasks running later on as crowbar, need to be able to write
+        # to the db directory
+        FileUtils.chown_R('crowbar', 'crowbar', File.join(target, 'crowbar_framework', 'db'))
       when "crowbar_engine"
         FileUtils.cp_r(File.join(@source,ent),dir) unless @source == dir
         if FileTest.exists?(File.join(dir,ent,"barclamp_"+@name+"/test/unit"))


### PR DESCRIPTION
The rake tasks run during install need write access to db/ and Gemfile.lock (for
the crowbar user).

Additionally this removes some "require chef" lines from the crowbar barclamp
which should no longer be needed as those were moved to the chef barclamp a
while ago.

 releases/development/master/extra/barclamp_install.rb | 3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: a55f560041623e39f315a64487b815f8f52b2fd9

Crowbar-Release: development
