### PR TITLE
Fix kiwi config for openSUSE 12.3

### DIFF
--- a/opensuse-12.3-extra/kiwi/source/config.xml
+++ b/opensuse-12.3-extra/kiwi/source/config.xml
@@ -94,6 +94,7 @@
   <packages type='bootstrap'>
     <package name='filesystem'/>
     <package name='glibc-locale'/>
+    <package name='module-init-tools'/>
   </packages>
   <repository type='yast2'>
     <source path='http://download.opensuse.org/distribution/12.3/repo/oss/'/>


### PR DESCRIPTION
Force module-init-tools to be installed, otherwise zypper would automactically
choose kmod-compat which would lead to a conflict with kernel-default later on.
