### PR TITLE
Enable unattended installation in kiwi config

### DIFF
--- a/opensuse-12.3-extra/kiwi/source/config.xml
+++ b/opensuse-12.3-extra/kiwi/source/config.xml
@@ -10,6 +10,7 @@
       <oemconfig>
         <oem-swap>true</oem-swap>
         <oem-swapsize>512</oem-swapsize>
+        <oem-unattended>true</oem-unattended>
       </oemconfig>
     </type>
     <version>0.0.1</version>


### PR DESCRIPTION
To avoid any interaction during installation.
