### PR TITLE
fix file not found for <repo>.tar.bz2 [1/1]

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -816,7 +816,7 @@ barclamp_git_repo_cache_needs_update() {
 }
 
 update_barclamp_git_repo_cache() {
-    local repo_name repo_url repo_branches
+    local repo_name repo_url repo_branches bc_cache="$CACHE_DIR/barclamps/$1/git_repos"
     mkdir -p "$bc_cache"
     while read repo_name repo_url repo_branches; do
         [[ $repo_branches ]] || repo_branches=master


### PR DESCRIPTION
fix file not found for <repo>.tar.bz2 

 build_lib.sh |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: ef4e84ccf349dcf460383b55b53942850991c0ad

Crowbar-Release: pebbles
