### PR TITLE
chef-install.sh fails to kill chef-server from upstart and bring it up with bluepill

### DIFF
--- a/releases/pebbles/master/extra/install-chef.sh
+++ b/releases/pebbles/master/extra/install-chef.sh
@@ -216,7 +216,8 @@ if [[ ! -x /etc/init.d/bluepill ]]; then
 
     # Sometimes chef-server does not die either.  Kill it with fire
     if ps aux |grep -q [c]hef-server; then
-        killall -9 chef-server chef-server-webui
+        ps axu | grep '^chef.*chef-server ' | awk '{print $2}' | xargs kill -9
+        ps axu | grep '^chef.*chef-server-webui ' | awk '{print $2}' | xargs kill -9
     fi
 
     # Create an init script for bluepill


### PR DESCRIPTION
killall -9 chef-server chef-server-webui missed child processes like
chef     22145  4.2  1.3 160048 56136 ?        Sl   06:56   0:01 merb : chef-server (api) : worker (ports 4001)
