### PR TITLE
add guard-rsync and two Guardfiles for two different approaches to merging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ gem "knife-essentials", "~> 0.7.6"
 # not working at the moment due to array in cookbookpath
 # gem "knife-github-cookbooks", "~> 0.1.6", :git => "https://github.com/iteh/knife-github-cookbooks.git" #
 
-gem "foodcritic", "~> 1.5.1"
+gem "foodcritic", ">= 1.5.1"
 
-
+group :development do
+  gem 'guard', ">= 1.8.0"
+  gem 'guard-rsync', :github => "aspiers/guard-rsync", :branch => "crowbar"
+  gem 'rb-inotify', "~> 0.9"
+  gem 'pry-debugger'
+end

--- a/Guardfile.mirror
+++ b/Guardfile.mirror
@@ -1,0 +1,52 @@
+#!/usr/bin/ruby
+#
+# Guardfile which uses guard-rsync to perform a real-time mirror of
+# the entire Crowbar tree (including barclamps) to another location,
+# e.g. inside a VM, where you can then run barclamp_install.rb etc.
+# to install the files to their final location in the merged tree
+# under /opt/dell.
+#
+# This is a different approach to Guardfile.tree-merge, which rsyncs
+# the files directly to the merged tree, skipping any installation
+# actions such as uploading cookbooks via knife, etc.
+#
+# Usage
+# -----
+#
+# First ensure you have the necessary gems by cd'ing to this directory
+# and running 'bundle'.  Doing this inside an rvm gemset is recommended.
+#
+# Then use as follows:
+#
+#   # Set the rsync target; this can also be a local path
+#   $ export GUARD_RSYNC_TARGET=root@192.168.124.10:/root/crowbar
+#
+#   # Launch the guard watcher:
+#   $ bundle exec guard -G Guardfile.mirror
+#
+# Further info
+# ------------
+#
+# More about Guard at https://github.com/guard/guard#readme
+
+TARGET = ENV['GUARD_RSYNC_TARGET']
+raise "Must set GUARD_RSYNC_TARGET" if TARGET.nil? or TARGET.empty?
+unless File.directory? TARGET or TARGET.include? ':'
+  raise "GUARD_RSYNC_TARGET set to non-directory: #{TARGET}"
+end
+
+group :rsync do
+  guard_opts = {
+    :input => './',
+    :output => TARGET,
+    :excludes => [
+      '.git/',
+      '/.ci-tracking/',
+      '.#*#',
+    ],
+    #:extra => ['-P'],
+  }
+  guard('rsync', guard_opts) do
+    watch(%r{.+})
+  end
+end

--- a/Guardfile.top
+++ b/Guardfile.top
@@ -1,0 +1,61 @@
+#!/usr/bin/ruby
+#
+# Guardfile which uses guard-rsync to sync installation scripts
+# from the Crowbar top-level repo to /opt/dell/bin.
+#
+# The target location of the merge can be a local path or an rsync
+# target such as root@192.168.124.10:/opt/dell/bin
+#
+# Unfortunately https://github.com/guard/listen/issues/25 breaks
+# watching of releases/$RELEASE/$BRANCH/extra/ when the current
+# directory is the Crowbar top-level, due to the extra/ symlink to it.
+# We work around this by starting guard inside the extra/
+# subdirectory.
+#
+# Usage
+# -----
+#
+# First ensure you have the necessary gems by cd'ing to this directory
+# and running 'bundle'.  Doing this inside an rvm gemset is recommended.
+#
+# Then use as follows:
+#
+#   # Optionally set the rsync target; defaults to /opt/dell/bin
+#   $ export GUARD_RSYNC_TARGET=root@192.168.124.10:/opt/dell/bin
+#
+#   # Launch the guard watcher:
+#   $ bundle exec guard -G `pwd`/Guardfile.top -w releases/pebbles/master/extra
+#
+# Note that "-w extra" will *not* work here due to the above-mentioned bug.
+#
+# Further info
+# ------------
+#
+# More about Guard at https://github.com/guard/guard#readme
+
+TARGET = ENV['GUARD_RSYNC_TARGET'] || '/opt/dell/bin'
+
+group :top do
+  # FIXME: The list of files to copy is release-specific, so this file
+  # should probably be moved to releases/$release.  But by the time it
+  # starts mattering, hopefully we won't be doing all development on the
+  # master branch of this repo.
+  globs = [
+    "barclamp_*.rb",
+    "install-chef-suse.sh",
+    "bc-dns-json.rb",
+    "bc-network-admin-helper.rb",
+  ]
+  filters = globs.map {|f| "+ #{f}"} + ["- /*"]
+  guard_opts = {
+    :input => './',
+    :output => TARGET,
+    :excludes => filters + ["- .#*#"],
+  }
+  guard('rsync', guard_opts) do
+    globs.each do |glob|
+      regexp = Regexp.new('^' + glob.gsub('.', '\.').gsub('*', '.*') + '$')
+      watch(regexp)
+    end
+  end
+end

--- a/Guardfile.tree-merge
+++ b/Guardfile.tree-merge
@@ -1,0 +1,92 @@
+#!/usr/bin/ruby
+#
+# Guardfile which uses guard-rsync to perform a real-time merge of the
+# Crowbar repositories into a single hierarchy like the one which ends
+# up under /opt/dell, or under /tmp/crowbar-dev-test/opt/dell when
+# ./dev tests setup is run.
+#
+# The target location of the merge can be a local path or an rsync
+# target such as root@192.168.124.10:/opt/dell
+#
+# This is a different approach to Guardfile.mirror, which mirrors the
+# tree without performing any merging; it skips the need for manual
+# runs of barclamp_install.rb, but has the consequent disadvantage of
+# not taking care of uploading cookbooks via knife, etc.
+#
+# Usage
+# -----
+#
+# First ensure you have the necessary gems by cd'ing to this directory
+# and running 'bundle'.  Doing this inside an rvm gemset is recommended.
+#
+# Then use as follows:
+#
+#   # Optionally set the rsync target; defaults to /tmp/crowbar-dev-test/opt/dell
+#   $ export GUARD_RSYNC_TARGET=root@192.168.124.10:/opt/dell
+#
+#   # Create the barclamps/ subdirectory so that rsyncing crowbar.yml files works
+#   $ ssh root@192.168.124.10 mkdir -p /opt/dell/barclamps
+#
+#   # Launch the guard watcher:
+#   $ bundle exec guard -G Guardfile.tree-merge
+#
+# Further info
+# ------------
+#
+# More about Guard at https://github.com/guard/guard#readme
+
+TARGET = ENV['GUARD_RSYNC_TARGET'] || '/tmp/crowbar-dev-test/opt/dell'
+
+# This has to match how barclamp_install.rb (in 2.0) and
+# barclamp_mgmt_lib.rb (< 2.0) do the tree merging.
+#
+# FIXME: The tree merging logic is release-specific, so this file
+# should probably be moved to releases/$release.  But by the time it
+# starts mattering, hopefully we won't be doing all development on the
+# master branch of this repo.
+BC_FILTERS = [
+  "+ /BDD/",
+  "+ /bin/",
+  "+ /chef/",
+  "+ /crowbar_framework/",
+  # FIXME: barclamp_install.rb in 2.0 does fancy stuff
+  #"+ /crowbar_engine/",
+  "+ /doc/",
+  "+ /etc/",
+  "+ /updates/",
+  "- /*",
+]
+
+GENERAL_EXCLUDES = [
+  "- .#*#",
+]
+
+def guard_bc_dir(bc_dir)
+  guard_opts = {
+    :input => bc_dir + '/',
+    :output => TARGET,
+    :excludes => BC_FILTERS + GENERAL_EXCLUDES,
+  }
+  guard('rsync', guard_opts) do
+    watch(%r{^#{bc_dir}/.+})
+  end
+end
+
+def guard_bc_yaml(bc_dir)
+  bc_yaml = bc_dir + '/crowbar.yml'
+  return unless File.exist? bc_yaml
+  guard_opts = {
+    :input => bc_yaml,
+    :output => TARGET + '/' + bc_dir + '/',
+  }
+  guard('rsync', guard_opts) do
+    watch("#{bc_dir}/crowbar.yml")
+  end
+end
+
+group :barclamps do
+  Dir.glob('barclamps/*').each do |bc_dir|
+    guard_bc_dir  bc_dir
+    guard_bc_yaml bc_dir
+  end
+end

--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -133,6 +133,7 @@ class BarclampFS
     @metadata[k]
   end
 
+  # N.B. if you update this, you must also update Guardfile.tree-merge !!
   def install_app
     STDERR.puts "Installing #{@name} from #{@source} into #{target}"
     dirs = Dir.entries(@source)

--- a/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
@@ -370,6 +370,7 @@ def framework_permissions(bc, path, options={})
 end
 
 # install the framework files for a barclamp
+# N.B. if you update this, you must also update Guardfile.tree-merge !!
 def bc_install_layout_1_app(bc, path, barclamp, options={})
   options = {:debug => false}.merge! options
   debug = options[:debug] or ENV['DEBUG'] === "true"


### PR DESCRIPTION
The documentation is currently in the comments header of each Guardfile - still need to add something to the devguide.

It's not the most elegant solution due to the DRY violation, but it should be useful in a lot of cases.

See http://publishwith.me/crowbar-tree-merging for the design background.

Currently uses `guard-rsync` from my github repo; if/when kselden/guard-rsync#8 is accepted, this can be changed to point back to the upstream version.

Please don't merge this until at least one person other than myself has tested and +1'd !
