### PR TITLE
Handle abandoning a nic when the network barclamp takes over a system. [4/4]

### DIFF
--- a/test_framework/network-team.json
+++ b/test_framework/network-team.json
@@ -60,15 +60,15 @@
           "pattern": "team/.*/.*",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1", "1g2" ],
+              "if_list": [ "1g2", "1g3" ],
               "team_mode": 5
             },
             "intf1": {
-              "if_list": [ "1g1", "1g2" ],
+              "if_list": [ "1g2", "1g3" ],
               "team_mode": 5
             },
             "intf2": {
-              "if_list": [ "1g1", "1g2" ],
+              "if_list": [ "1g2", "1g3" ],
               "team_mode": 5
             }
           }
@@ -77,13 +77,13 @@
           "pattern": "dual/.*/.*",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1" ]
-            },
-            "intf1": {
               "if_list": [ "1g2" ]
             },
+            "intf1": {
+              "if_list": [ "1g3" ]
+            },
             "intf2": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             }
           }
         },
@@ -91,13 +91,13 @@
           "pattern": "single/.*/.*",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf1": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf2": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             }
           }
         },
@@ -105,13 +105,13 @@
           "pattern": ".*/.*/.*",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf1": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf2": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             }
           }
         },
@@ -119,13 +119,13 @@
           "pattern": "mode/1g_adpt_count/role",
           "conduit_list": { 
             "intf0": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf1": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             },
             "intf2": {
-              "if_list": [ "1g1" ]
+              "if_list": [ "1g2" ]
             }
           }
         }
@@ -246,4 +246,3 @@
     }
   }
 }
-

--- a/test_lib.sh
+++ b/test_lib.sh
@@ -75,7 +75,7 @@ export CROWBAR_KEY="crowbar:crowbar"
 # Please keep it at 4 characters or less.
 SMOKETEST_BRIDGES=(crowbar-pub)
 
-NICS_PER_BRIDGE=2
+NICS_PER_BRIDGE=3
 
 # An array of physical interfaces and the bridges they should be bound to.
 # We need to use real physical interfaces becasue Crowbar assumes


### PR DESCRIPTION
The network barclamp now properly handles the scenario where we
abandon the interface we initially PXE booted and installed from, and
the default smoketest now tests that configuration.

 test_framework/network-team.json |   31 +++++++++++++++----------------
 test_lib.sh                      |    2 +-
 2 files changed, 16 insertions(+), 17 deletions(-)

Crowbar-Pull-ID: dd3666f0c95a7d5b43e788a8e2c8b5d2e1e2e7bd

Crowbar-Release: pebbles
