### PR TITLE
Add gre mode support to Quantum. [4/4]

### DIFF
--- a/test_framework/network-dual.json
+++ b/test_framework/network-dual.json
@@ -207,7 +207,19 @@
             "host": { "start": "192.168.124.161", "end": "192.168.124.161" }
           }
         },
-        "admin": {
+          "os_sdn": {
+              "conduit": "intf1",
+              "vlan": 700,
+              "use_vlan": true,
+              "add_bridge": false,
+              "subnet": "192.168.130.0",
+              "netmask": "255.255.255.0",
+              "broadcast": "192.168.130.255",
+              "ranges": {
+                  "host": { "start": "192.168.130.10", "end": "192.168.130.254"}
+              }
+          },
+          "admin": {
           "conduit": "intf0",
           "vlan": 100,
           "use_vlan": false,

--- a/test_framework/network-single.json
+++ b/test_framework/network-single.json
@@ -207,7 +207,19 @@
             "host": { "start": "192.168.124.161", "end": "192.168.124.161" }
           }
         },
-        "admin": {
+          "os_sdn": {
+              "conduit": "intf1",
+              "vlan": 700,
+              "use_vlan": true,
+              "add_bridge": false,
+              "subnet": "192.168.130.0",
+              "netmask": "255.255.255.0",
+              "broadcast": "192.168.130.255",
+              "ranges": {
+                  "host": { "start": "192.168.130.10", "end": "192.168.130.254"}
+              }
+          },
+          "admin": {
           "conduit": "intf0",
           "vlan": 100,
           "use_vlan": false,

--- a/test_framework/network-team.json
+++ b/test_framework/network-team.json
@@ -162,13 +162,13 @@
           "conduit": "intf1",
           "vlan": 500,
           "use_vlan": true,
-          "add_bridge": true,
+          "add_bridge": false,
           "subnet": "192.168.127.0",
           "netmask": "255.255.255.0",
           "broadcast": "192.168.127.255",
           "ranges": {
-            "router": { "start": "192.168.127.2", "end": "192.168.127.49" },
-            "dhcp": { "start": "192.168.127.50", "end": "192.168.127.254" }
+            "router": { "start": "192.168.127.10", "end": "192.168.127.59" },
+            "dhcp": { "start": "192.168.127.60", "end": "192.168.127.254" }
           }
         },
         "nova_floating": {
@@ -207,6 +207,18 @@
             "host": { "start": "192.168.128.2", "end": "192.168.128.9" }
           }
         },
+          "os_sdn": {
+              "conduit": "intf1",
+              "vlan": 700,
+              "use_vlan": true,
+              "add_bridge": false,
+              "subnet": "192.168.130.0",
+              "netmask": "255.255.255.0",
+              "broadcast": "192.168.130.255",
+              "ranges": {
+                  "host": { "start": "192.168.130.10", "end": "192.168.130.254"}
+              }
+          },
         "admin": {
           "conduit": "intf0",
           "vlan": 100,


### PR DESCRIPTION
This pull request does the following things:
- Clean up interface creation on quantum and nova nodes, mostly by
  not creating any interfaces we don't have to.
- Stop creating a helper route to get to the quantum metadata
  server.  We have a working metadata proxy, so it just interferes
  with the other networking mode.
- Add support for running quantum in GRE tunnelling mode.  This
  requires a dedicated network (named os_sdn (as in openstack
  software defined network)) seperate from the other networks.  The
  default network config for os_sdn in the network.json looks like
  this:
        "os_sdn": {
            "conduit": "intf1",
            "vlan": 700,
            "use_vlan": true,
            "add_bridge": false,
            "subnet": "192.168.130.0",
            "netmask": "255.255.255.0",
            "broadcast": "192.168.130.255",
            "ranges": {
                "host": { "start": "192.168.130.10", "end": "192.168.130.254"}
            }
        },
  This network is what Quantum uses to tie the OVS switches together
  with GRE tunnels.
- Modify the Nova smoketest to only operate with floating IP
  addresses.  When Quantum is running in GRE mode, it is not possible
  without doing something extremly foolish for a tenant network to
  talk directly with the outside world.
  
  test_framework/network-dual.json   |   14 +++++++++++++-
  test_framework/network-single.json |   14 +++++++++++++-
  test_framework/network-team.json   |   18 +++++++++++++++---
  3 files changed, 41 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: c9539d81711c2214b06995a82fd0ca64896a1732

Crowbar-Release: pebbles
