### PR TITLE
Add barclamp-database to openstack-os-build [1/1]

### DIFF
--- a/releases/pebbles/openstack-os-build/barclamp-database
+++ b/releases/pebbles/openstack-os-build/barclamp-database
@@ -1,0 +1,1 @@
+release/pebbles/master


### PR DESCRIPTION
Add barclamp-database to openstack-os-build.

 .../pebbles/openstack-os-build/barclamp-database   |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 0f7045051f053ba0808cfed4abf8717583bf6ab5

Crowbar-Release: pebbles
