### PR TITLE
remove barclamp-database from build temporarily [1/1]

### DIFF
--- a/releases/pebbles/openstack-os-build/barclamp-database
+++ b/releases/pebbles/openstack-os-build/barclamp-database
@@ -1,1 +1,0 @@
-release/pebbles/master


### PR DESCRIPTION
remove barclamp-database from build temporarily

 .../pebbles/openstack-os-build/barclamp-database   |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: cb648a624aeb60ded7c2023b548e6b4951deb159

Crowbar-Release: pebbles
