### PR TITLE
barclamp_uninstall.rb: Add --debug, --rpm and --help flags

### DIFF
--- a/releases/pebbles/master/extra/barclamp_install.rb
+++ b/releases/pebbles/master/extra/barclamp_install.rb
@@ -31,7 +31,7 @@ opts = GetoptLong.new(
 
 def usage()
   puts "Usage:"
-  puts "#{__FILE__} [--help] [--debug] /path/to/new/barclamp"
+  puts "#{__FILE__} [--help] [--rpm] [--debug] /path/to/new/barclamp"
   exit
 end
 

--- a/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
@@ -335,7 +335,7 @@ def merge_tree(key, value, target)
 end
 
 # cleanup (anti-install) assumes the install generates a file list
-def bc_remove_layout_1(bc, bc_path, yaml)
+def bc_remove_layout_1(from_rpm, bc, bc_path, yaml)
   filelist = File.join BARCLAMP_PATH, "#{bc}-filelist.txt"
   if File.exist? filelist
     files = [ filelist ]

--- a/releases/pebbles/master/extra/barclamp_uninstall.rb
+++ b/releases/pebbles/master/extra/barclamp_uninstall.rb
@@ -20,7 +20,36 @@
   # however, that code is not always available when installing
 
 require '/opt/dell/bin/barclamp_mgmt_lib.rb'
-    
+require 'getoptlong'
+
+opts = GetoptLong.new(
+  [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
+  [ '--debug', '-d', GetoptLong::NO_ARGUMENT ],
+  [ '--rpm', GetoptLong::NO_ARGUMENT ]
+)
+
+def usage()
+  puts "Usage:"
+  puts "#{__FILE__} [--help] [--rpm] [--debug] /path/to/old/barclamp"
+  exit
+end
+
+from_rpm = false
+
+opts.each do |opt, arg|
+  case opt
+    when "--help"
+    usage
+    when "--debug"
+    @@debug = true
+    debug "debug mode is enabled"
+    when "--rpm"
+    from_rpm = true
+  end
+end
+
+usage if ARGV.length < 1
+
   # this is used by the install-chef installer script 
   if __FILE__ == $0
     path = ARGV[0]
@@ -34,7 +63,7 @@ require '/opt/dell/bin/barclamp_mgmt_lib.rb'
     bc = barclamp["barclamp"]["name"].chomp.strip
     case barclamp["crowbar"]["layout"].to_i
     when 1
-      bc_remove_layout_1 bc, path, barclamp
+      bc_remove_layout_1 from_rpm, bc, path, barclamp
       #TODO: bc_remove_layout_1_chef bc, path, barclamp
     else
       puts "ERROR: could not UNinstall barclamp #{bc} because #{barclamp["barclamp"]["crowbar_layout"]} is unknown layout."


### PR DESCRIPTION
Right now, --rpm doesn't change any behavior, but having this flag to be
consistent with barclamp_install.rb makes sense.
