### PR TITLE
Add database barclamp into openstack-os-build [1/1]

### DIFF
--- a/releases/pebbles/openstack-os-build/barclamp-database
+++ b/releases/pebbles/openstack-os-build/barclamp-database
@@ -1,0 +1,1 @@
+release/pebbles/master


### PR DESCRIPTION
Add database barclamp into openstack-os-build.

 .../pebbles/openstack-os-build/barclamp-database   |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: e4d39a97b080debfe0f2798a8dec5f813c2ef87c

Crowbar-Release: pebbles
