### PR TITLE
install-chef-suse: nicer output

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -19,7 +19,8 @@ if [ "$1" = "--from-git" ]; then
     sed -i -e '/"nagios":/d' -e '/"ganglia":/d' $CROWBAR_FILE
 fi
 
-LOGFILE=/var/log/chef/install.log
+LOGFILE=/var/log/crowbar/install.log
+mkdir -p "`dirname "$LOGFILE"`"
 
 : ${BARCLAMP_SRC:="/opt/dell/barclamps/"}
 


### PR DESCRIPTION
This significantly unclutters the output of install-chef-suse.sh, while improving it with a nice spinner. And all the details are still logged in the log file.
