### PR TITLE
Remove mysql barclamp from openstack build [1/1]

### DIFF
--- a/releases/pebbles/openstack-os-build/barclamp-mysql
+++ b/releases/pebbles/openstack-os-build/barclamp-mysql
@@ -1,1 +1,0 @@
-release/pebbles/master


### PR DESCRIPTION
Remove mysql barclamp from openstack build

 releases/pebbles/openstack-os-build/barclamp-mysql |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 7d13fe4803942233179a522dedfd91b89d7e1ce3

Crowbar-Release: pebbles
