### PR TITLE
install-chef-suse: Update bc-template-provisioner.json only when needed

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -550,15 +550,12 @@ for service in $services; do
 done
 
 
-provisioner_template=/opt/dell/chef/data_bags/crowbar/bc-template-provisioner.json
-[ -f $provisioner_template ] || die "$provisioner_template doesn't exist"
-/opt/dell/bin/bc-provisioner-json.rb < $provisioner_template > $provisioner_template.new
-cmp --silent $provisioner_template $provisioner_template.new
-if [ $? -ne 0 ]; then
+if [ -f /root/.ssh/authorized_keys ]; then
+    provisioner_template=/opt/dell/chef/data_bags/crowbar/bc-template-provisioner.json
+    [ -f $provisioner_template ] || die "$provisioner_template doesn't exist"
+    /opt/dell/bin/bc-provisioner-json.rb < $provisioner_template > $provisioner_template.new
     cp -a $provisioner_template $provisioner_template.orig
     mv $provisioner_template.new $provisioner_template
-else
-    rm $provisioner_template.new
 fi
 
 # Initial chef-client run


### PR DESCRIPTION
We should only run bc-provisioner-json.rb if /root/.ssh/authorized_keys
exists. Otherwise, even if it doesn't exist, it will output a json file
which will be different than the original file.

Thanks to Bernhard M. Wiedemann for spotting this!
