### PR TITLE
Fix script aborting immediately when compare fails

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -553,8 +553,7 @@ done
 provisioner_template=/opt/dell/chef/data_bags/crowbar/bc-template-provisioner.json
 [ -f $provisioner_template ] || die "$provisioner_template doesn't exist"
 /opt/dell/bin/bc-provisioner-json.rb < $provisioner_template > $provisioner_template.new
-cmp --silent $provisioner_template $provisioner_template.new
-if [ $? -ne 0 ]; then
+if ! cmp --silent $provisioner_template $provisioner_template.new ; then
     cp -a $provisioner_template $provisioner_template.orig
     mv $provisioner_template.new $provisioner_template
 else


### PR DESCRIPTION
In bash -e mode, you can't use $?.
