### PR TITLE
install-chef-suse: Fix comandline option handling

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -22,7 +22,7 @@ EOF
 
 while test $# -gt 0; do
     case "$1" in
-        -h|--help|--usage|-?) usage ;;
+        -h|--help|--usage|-\?) usage ;;
         -v|--verbose) CROWBAR_VERBOSE=1 ;;
         --from-git) CROWBAR_FROM_GIT=1 ;;
         *) ;;


### PR DESCRIPTION
The unescaped '?' was catching all single letter args. So -v was not working as
expected.
