### PR TITLE
Find rpm name by using the basename of the barclamp path

### DIFF
--- a/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
@@ -465,7 +465,7 @@ def bc_install_layout_1_chef(from_rpm, bc, bc_path, yaml)
   roles = File.join chef, 'roles'
 
   if from_rpm
-    rpm = 'crowbar-barclamp-' + bc
+    rpm = 'crowbar-barclamp-' + File.basename(bc_path)
     debug "obtaining chef components from #{rpm} rpm"
     rpm_files = get_rpm_file_list(rpm)
     upload_cookbooks_from_rpm rpm, rpm_files, bc_path, log


### PR DESCRIPTION
The issue with using the barclamp id is that some characters might not
be correct (_ instead of -, for instance).
