### PR TITLE
install-chef-suse: More cleanup when reinstalling crowbar

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -619,6 +619,10 @@ for i in $BARCLAMP_SRC/*; do
         /opt/dell/bin/barclamp_uninstall.rb $BARCLAMP_INSTALL_OPTS $i
     fi
 done
+# Clean up files that are created for handling node discovery by provisioner barclamp
+test -d /etc/dhcp3/hosts.d && rm /etc/dhcp3/hosts.d/*
+test -d /srv/tftpboot/discovery && rm /srv/tftpboot/discovery/*.conf
+test -d /srv/tftpboot/discovery/pxelinux.cfg && rm /srv/tftpboot/discovery/pxelinux.cfg/*
 
 # Don't use this one - crowbar barfs due to hyphens in the "id" attribute.
 #CROWBAR_FILE="/opt/dell/barclamps/crowbar/chef/data_bags/crowbar/bc-template-crowbar.json"


### PR DESCRIPTION
Remove files created by provisioner barclamp to allow nodes to get
re-discovered.
