### PR TITLE
install-chef-suse: Install updater and suse-manager-client barclamps

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -673,6 +673,13 @@ for i in deployer dns ipmi logging nagios network ntp provisioner \
     /opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS $BARCLAMP_SRC/$i
 done
 
+# Install optional barclamps if they're present
+for i in updater suse-manager-client ; do
+    if test -d $BARCLAMP_SRC/$i; then
+        /opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS $BARCLAMP_SRC/$i
+    fi
+done
+
 
 # First step of crowbar bootstrap
 # -------------------------------


### PR DESCRIPTION
We only do that if they're present, as these barclamps are not strictly
required.
