### PR TITLE
Fix multiple calls to bc-provisioner-json.rb

### DIFF
--- a/releases/pebbles/master/extra/bc-provisioner-json.rb
+++ b/releases/pebbles/master/extra/bc-provisioner-json.rb
@@ -5,10 +5,11 @@ require 'rubygems'
 require 'json'
 
 keys = File.read('/root/.ssh/authorized_keys') rescue ""
+keys.strip!
 
 databag = JSON.load($stdin)
 if keys != ""
-  databag['attributes']['provisioner']['access_keys'] += "\n" + keys;
+  databag['attributes']['provisioner']['access_keys'] = [databag['attributes']['provisioner']['access_keys'], keys].join("\n").strip
 end
 
 puts JSON.pretty_generate databag


### PR DESCRIPTION
Up until now, bc-provisioner-json.rb was keeping leading and trailing
newlines, which was resulting in empty lines when calling
bc-provisioner-json.rb. The issue is that empty lines break crowbar in
interesting ways. We'll fix that too, but at least, we can already make
sure to not cause that bug.
