### PR TITLE
Just sort pull requests by creation time in ./dev pull-requests list [1/1]

### DIFF
--- a/dev
+++ b/dev
@@ -937,16 +937,11 @@ pull_request_last_touched() (
         for d in *; do
             [[ -d $d ]] || continue
             [[ $ltime ]] || read ltime <"$d/created_at"
-            [[ -f updated_at ]] && read $d/ltime <"$d/updated_at"
             [[ $ltime > $mtime ]] && mtime=$ltime
         done
         echo $mtime
     elif [[ $1 = singletons/* ]]; then
-        if [[ -f $OPEN_PULL_REQUESTS/$1/updated_at ]]; then
-            cat "$OPEN_PULL_REQUESTS/$1/updated_at"
-        else
-            cat "$OPEN_PULL_REQUESTS/$1/created_at"
-        fi
+        cat "$OPEN_PULL_REQUESTS/$1/created_at"
     else
         die "No idea how to find last touched time for $1"
     fi


### PR DESCRIPTION
This changes the order in which pull requests are displayed to display
them by create time instead of last modified time.  It turns out that
last modified time includes the last time a pull request was commented
on, which makes the list ordering change too often.

 dev |    7 +------
 1 file changed, 1 insertion(+), 6 deletions(-)

Crowbar-Pull-ID: 528544fd774dfe3ac331143430a2d38dea940193

Crowbar-Release: pebbles
