### PR TITLE
Add handy test console command

### DIFF
--- a/dev
+++ b/dev
@@ -4164,6 +4164,13 @@ run_server() {
   RAILS_ENV=development bundle exec script/rails s Puma development
 }
 
+run_console() {
+  auto_reload_test_env
+  cd "$CROWBAR_TEST_DIR/opt/dell/crowbar_framework"
+  echo "Starting Rails console"
+  RAILS_ENV=development bundle exec script/rails c
+}
+
 run_tests() {
     run_unit_tests
     run_BDD_tests
@@ -4389,6 +4396,7 @@ tests_handler() {
         run-units) run_unit_tests          "$@" ;;
         run-BDD)   run_BDD_tests           "$@" ;;
         server)    run_server              "$@" ;;
+        console)   run_console             "$@" ;;
         reload)    reload_test_env         "$@" ;;
         clear)     clear_test_env          "$@" ;;
         *)         dev_help tests               ;;
@@ -4735,6 +4743,8 @@ DEV_LONG_HELP["tests"]="Various tasks related to running tests.
       Run unit tests and specs from the /tmp/crowbar environment.
     server
       Run the dev web server interactively
+    console
+      Run the dev console interactively
     clear
       Removes a test environment in /tmp/crowbar."
 DEV_LONG_HELP["setup-unit-tests"]="Deprecated; please see help for ./dev tests setup"


### PR DESCRIPTION
This shortcut allows you to use the console with the latest code from dev instead of finding it in the /tmp directory
