### PR TITLE
DE1377 Removing loadbalancer barclamp from mesa 1.6 [1/1]

### DIFF
--- a/releases/mesa-1.6/openstack-os-build/barclamp-loadbalancer
+++ b/releases/mesa-1.6/openstack-os-build/barclamp-loadbalancer
@@ -1,1 +1,0 @@
-release/mesa-1.6/master


### PR DESCRIPTION
DE1377 We should not expose loadbalancer barclamp in Mesa-1.6

 .../openstack-os-build/barclamp-loadbalancer       |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 0ce6ded6c6bc837053fa91040b84e89644ab7346

Crowbar-Release: mesa-1.6
