### PR TITLE
Add --1.x option for Crowbar 1.x (Pebbles)

### DIFF
--- a/travis-ci/update-git.sh
+++ b/travis-ci/update-git.sh
@@ -7,6 +7,8 @@
 : ${TRAVIS_GIT_DIR:=~/travis-ci-crowbar}
 # It can be cloned from: https://github.com/crowbar/travis-ci-crowbar
 
+: ${DEV_TEST_DIR:=/tmp/crowbar-dev-test/opt/dell}
+
 function load_rvm() {
   if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
     source "$HOME/.rvm/scripts/rvm"
@@ -19,6 +21,7 @@ function usage() {
   echo "
   Script to update the combined git repository.
 
+    --1.x       Use for Crowbar 1.x (eg. Pebbles)
     --no-fetch  Don't run ./dev fetch
     --no-sync   Don't run ./dev sync
     --gem-cache Use gem cache
@@ -46,29 +49,43 @@ function update_with_dev_tool() {
   [[ $dev_fetch = true ]] && run "./dev fetch"
   [[ $dev_sync  = true ]] && run "./dev sync"
   log "Setting up test environment using $CROWBAR_DIR ..."
-  if [[ $dev_test_mode = setup ]]; then
-      if [[ $use_gem_cache = true ]]; then
-          run "./dev tests setup"
-      else
-          run "./dev tests setup --no-gem-cache"
-      fi
-  elif [[ $dev_test_mode = reload ]]; then
-      run "./dev tests reload"
+
+  if [[ $crowbar_1_x = true ]]; then
+    rm -rf   $DEV_TEST_DIR
+    mkdir -p $DEV_TEST_DIR
+    DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+    for barclamp in cinder crowbar database deployer dns glance ipmi keystone \
+        logging nagios network nova nova_dashboard ntp provisioner quantum \
+        rabbitmq swift; do
+      cp -a $DIR/barclamps/$barclamp/{chef,crowbar_framework} $DEV_TEST_DIR/
+    done
   else
-      die "BUG: invalid mode $dev_test_mode"
+    if [[ $dev_test_mode = setup ]]; then
+        if [[ $use_gem_cache = true ]]; then
+            run "./dev tests setup"
+        else
+            run "./dev tests setup --no-gem-cache"
+        fi
+    elif [[ $dev_test_mode = reload ]]; then
+        run "./dev tests reload"
+    else
+        die "BUG: invalid mode $dev_test_mode"
+    fi
   fi
 }
 
 function rsync_files() {
-  local DEV_TEST=/tmp/crowbar-dev-test
-  cd "$TRAVIS_GIT_DIR"
   log "Copying files..."
+  cd "$TRAVIS_GIT_DIR"
   git reset -q --hard HEAD
   git clean -f -d -q
-  rsync -aq --delete --exclude=.git/ \
-    $DEV_TEST/opt/dell/{barclamps,crowbar_framework} \
-    $DEV_TEST/opt/dell/crowbar_framework/Gemfile{,.lock} \
-    .
+  git checkout $BRANCH
+
+  sources="$DEV_TEST_DIR/chef $DEV_TEST_DIR/crowbar_framework"
+  if [[ $crowbar_1_x = false ]]; then
+    sources="$sources $DEV_TEST_DIR/barclamps"
+  fi
+  rsync -aq --delete --exclude=.git/ $sources .
 }
 
 # A number of JSON files are generated during barclamp installation. These
@@ -98,7 +115,7 @@ function commit_and_push() {
   git pull
   git add *
 
-  output=`git commit -a -m "Update to latest in https://github.com/crowbar/crowbar master" 2>&1`
+  output=`git commit -a -m "Update to latest in https://github.com/crowbar/crowbar $BRANCH" 2>&1`
   if [ $? -ne 0 ]; then
     if echo $output | grep -q "nothing to commit"; then
       log "Nothing to commit"
@@ -122,8 +139,10 @@ dev_fetch=true
 use_gem_cache=false
 dev_test_mode=setup
 git_push=true
+crowbar_1_x=false
 for opt in "$@"; do
   case $opt in
+    --1.x)       crowbar_1_x=true;;
     --no-fetch)  dev_fetch=false;;
     --no-sync)   dev_sync=false;;
     --gem-cache) use_gem_cache=true;;
@@ -141,6 +160,9 @@ fi
 CROWBAR_DIR=$( cd `dirname $0` && cd .. && pwd ) || \
     die "Couldn't determine location of Crowbar repository"
 TRAVIS_CI_DIR="$CROWBAR_DIR/travis-ci"
+
+BRANCH=master
+[[ $crowbar_1_x = true ]] && BRANCH=pebbles
 
 load_rvm
 update_with_dev_tool


### PR DESCRIPTION
This patch is needed to assemble a working Crowbar 1.x (eg. Pebbles) branch into a single Git repository, so we can more easily run the code analysis (eg. brakeman, tailor) and tests.

**Update:** We're already using this code in our [public Jenkins server](http://ci.opensuse.org/view/Crowbar/job/crowbar-pebbles-travis_ci-trackupstream/) to merge Pebbles (Crowbar 1.6) into a single Git repository. This in turn triggers the [Pebbles Travis CI](https://travis-ci.org/crowbar/travis-ci-crowbar/branches) job.
