### PR TITLE
Fix up pebbles/cloudera-build to build properly. [2/2]

### DIFF
--- a/releases/pebbles/cloudera-build/crowbar.json
+++ b/releases/pebbles/cloudera-build/crowbar.json
@@ -6,7 +6,7 @@
       "instances": {
         "deployer": [ "default" ],
         "ipmi": [ "default" ],
-        "bios": [ "default" ],
+        "dell_bios": [ "default" ],
         "dell_raid": [ "default" ],
         "provisioner": [ "default" ],
         "network": [ "default" ],


### PR DESCRIPTION
cloudera-manager-parcel has gone from 4.6.0 to 4.6.1, and the default
deployment needed to reference dell_bios instead of bios.

 releases/pebbles/cloudera-build/crowbar.json |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 6cb4dbd22f0ee49187dea948d7285834107926ea

Crowbar-Release: pebbles
