### PR TITLE
install-chef-suse: Use network config from /etc/crowbar/network.json

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -318,6 +318,12 @@ if [ -n "$IPv4_addr" ]; then
     if ! /opt/dell/bin/bc-network-admin-helper.rb "$IPv4_addr" < $NETWORK_JSON; then
         die "IPv4 address $IPv4_addr of Administration Server not in admin range of admin network. Please check and fix with yast2 crowbar. Aborting."
     fi
+
+    if [ -f /etc/crowbar/network.json ]; then
+        if ! /opt/dell/bin/bc-network-admin-helper.rb "$IPv4_addr" < /etc/crowbar/network.json; then
+            die "IPv4 address $IPv4_addr of Administration Server not in admin range of admin network. Please check and fix with yast2 crowbar. Aborting."
+        fi
+    fi
 fi
 if [ -n "$IPv6_addr" ]; then
     echo "$FQDN resolved to IPv6 address: $IPv6_addr"


### PR DESCRIPTION
If /etc/crowbar/network.json exists, then we want to use this as the
network configuration (with deep merge).
