### PR TITLE
Fix for allowing barclamp tarballs to have a "-barclamp" in the name [1/1]

### DIFF
--- a/releases/mesa-1.6/master/extra/barclamp_install.rb
+++ b/releases/mesa-1.6/master/extra/barclamp_install.rb
@@ -73,7 +73,8 @@ ARGV.each do |src|
     # This might be a barclamp tarball.  Expand it into a temporary location.
     src=File.expand_path(src)
     system "tar xzf \"#{src}\" -C \"#{tmpdir}\""
-    target="#{tmpdir}/#{src.split("/")[-1].split(".")[0]}"
+    # get the barclamp name, allow the tar ball to be named <barclampname>-barclamp.t*
+    target="#{tmpdir}/#{src.split("/")[-1].split(".")[0].chomp("-barclamp")}"
     if File.exists?(File.join(target,"crowbar.yml"))
       candidates << target
     else

--- a/releases/pebbles/master/extra/barclamp_install.rb
+++ b/releases/pebbles/master/extra/barclamp_install.rb
@@ -73,7 +73,8 @@ ARGV.each do |src|
     # This might be a barclamp tarball.  Expand it into a temporary location.
     src=File.expand_path(src)
     system "tar xzf \"#{src}\" -C \"#{tmpdir}\""
-    target="#{tmpdir}/#{src.split("/")[-1].split(".")[0]}"
+    # get the barclamp name, allow the tar ball to be named <barclampname>-barclamp.t*
+    target="#{tmpdir}/#{src.split("/")[-1].split(".")[0].chomp("-barclamp")}"
     if File.exists?(File.join(target,"crowbar.yml"))
       candidates << target
     else


### PR DESCRIPTION
Fix for allowing barclamp tarballs to have a "-barclamp" in the name

 releases/mesa-1.6/master/extra/barclamp_install.rb |    3 ++-
 releases/pebbles/master/extra/barclamp_install.rb  |    3 ++-
 2 files changed, 4 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: e41335763adcb3c0daf7f1e448bf8764f2b9d0d2

Crowbar-Release: mesa-1.6
