### PR TITLE
bnc#829301 - Unsigned repo warning

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -378,13 +378,16 @@ EOF
 
 sign_repositories () {
   # Currently we only sign the Cloud-PTF repository
-  if [ ! -f /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.asc -o ! -f /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.key ]; then
-    create_gpg_key
-    echo "Signing Cloud-PTF repository"
-    gpg -a --detach-sign /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml
-    gpg -a --export > /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.key
-  else
-    echo "Cloud-PTF repository is already signed"
+  if [ -f /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml ]; then
+    if [ ! -f /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.asc -o \
+         ! -f /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.key ]; then
+      create_gpg_key
+      echo "Signing Cloud-PTF repository"
+      gpg -a --detach-sign /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml
+      gpg -a --export > /srv/tftpboot/repos/Cloud-PTF/repodata/repomd.xml.key
+    else
+      echo "Cloud-PTF repository is already signed"
+    fi
   fi
 }
 


### PR DESCRIPTION
bnc#829301 - Installing packages from Cloud-PTF gives unsigned repo warning
This commit creates a gpg key on the admin node, if it does not already exist,
and signs the SUSE-Cloud-PTF repository and copies the public key to the
repository
