### PR TITLE
Do not switch cache branch when --no-cache-update is specified [1/1]

### DIFF
--- a/dev
+++ b/dev
@@ -3722,7 +3722,8 @@ build_crowbar() {
 	    --release) shift; target_release="$1";;
 	    --branch) shift; target_branch="$1";;
 	    --exact) exact=true;;
-            --no-switch) no_switch=true;;
+        --no-switch) no_switch=true;;
+        --no-cache-update) switch_include_cache=false;;
 	    *) build_args+=($1);;
 	esac
 	shift
@@ -3738,7 +3739,11 @@ build_crowbar() {
     if [[ $exact ]]; then
 	debug "Exact does not mean anything anymore."
     fi
+    if [[ $switch_include_cache = true ]];then
     maybe_checkout_build_cache_branch
+    else
+    debug "--no-cache-update enabled. So skip checking out the cache" 
+    fi
     with_build_lock exec "$CROWBAR_DIR/build_crowbar.sh" \
 	"$target_os" "${build_args[@]}"
     echo "Build process took ${SECONDS} seconds."


### PR DESCRIPTION
Do not automatically switch the cache branch if --no-cache-update option is specified. This helps to test with a different cache than the build 

 dev |    7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: f2f5dab8f0012f5d30f3d2559d7c164216f7f937

Crowbar-Release: pebbles
