### PR TITLE
fix to barclamp_create process

### DIFF
--- a/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
@@ -187,13 +187,14 @@ def bc_replacer(item, bc, entity)
   debug "bc_replacer method called with debug option enabled"
   debug "bc_replacer args: item=#{item}, bc=#{bc}, entity=#{entity}"
 
-  item.gsub!(MODEL_SUBSTRING_BASE, bc)
-  item.gsub!(MODEL_SUBSTRING_CAMEL, bc.camelize)
-  item.gsub!(MODEL_SUBSTRING_HUMAN, bc.humanize)
-  item.gsub!(MODEL_SUBSTRING_CAPSS, bc.capitalize)
-  item.gsub!('Copyright 2011, Dell', "Copyright #{Time.now.year}, #{entity}")
-  debug "bc_replacer returns item=#{item}"
-  return item
+  new_item = item.clone  
+  new_item.gsub!(MODEL_SUBSTRING_BASE, bc)
+  new_item.gsub!(MODEL_SUBSTRING_CAMEL, bc.camelize)
+  new_item.gsub!(MODEL_SUBSTRING_HUMAN, bc.humanize)
+  new_item.gsub!(MODEL_SUBSTRING_CAPSS, bc.capitalize)
+  new_item.gsub!('Copyright 2011, Dell', "Copyright #{Time.now.year}, #{entity}")
+  debug "bc_replacer returns new_item=#{new_item}"
+  return new_item
 end
 
 #merges localizations from config into the matching translation files


### PR DESCRIPTION
I have a fix for the issue with barclamp_create.rb raised by Keith Rochford in the Crowbar Digest, Vol 25, Issue 54 on 7/18/2013. This preserves the value of item in barclamp_create.rb and prevents it from being changed to an inappropriate value when used as a file source path
