### PR TITLE
barclamp_mgmt_lib: Fix crash when using --rpm mode

### DIFF
--- a/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/pebbles/master/extra/barclamp_mgmt_lib.rb
@@ -519,7 +519,6 @@ def get_rpm_file_list(rpm)
   cmd = "rpm -ql #{rpm}"
   file_list = `#{cmd}`.lines.map { |line| line.rstrip }
   raise cmd + " failed" unless $? == 0
-  raise "got empty file list from #{cmd}" if file_list.empty?
   debug "obtained file list from #{rpm} rpm"
   return file_list
 end


### PR DESCRIPTION
IO.popen() doesn't set $?, so we use `foo` to execute a command instead.
