### PR TITLE
Fixed issue where crowbar install hangs [1/1]

### DIFF
--- a/releases/roxy/master/extra/install-chef-suse.sh
+++ b/releases/roxy/master/extra/install-chef-suse.sh
@@ -879,7 +879,7 @@ if [[ $CROWBAR_REALM && -f /etc/crowbar.install.key ]]; then
 fi
 
 # Make sure looper_chef_client is a NOOP until we are finished deploying
-touch /tmp/deploying
+touch /var/run/crowbar/deploying
 # This works because
 #
 #   crowbar_framework/app/models/provisioner_service.rb
@@ -893,7 +893,7 @@ touch /tmp/deploying
 #
 #   /opt/dell/bin/looper_chef_client.sh
 #
-# which exits immediately if /tmp/deploying exists.
+# which exits immediately if /var/run/crowbar/deploying exists.
 
 # From here, you should probably read along with the equivalent steps in
 # install-chef.sh for comparison
@@ -964,7 +964,7 @@ echo_summary "Transitioning Administration Server to \"ready\""
 for state in "discovering" "discovered" "hardware-installing" \
     "hardware-installed" "installing" "installed" "readying" "ready"
 do
-    while [[ -f "/tmp/chef-client.lock" ]]; do sleep 1; done
+    while [[ -f "/var/run/crowbar/chef-client.lock" ]]; do sleep 1; done
     printf "$state: "
     $CROWBAR crowbar transition "$FQDN" "$state" || \
         die "Transition to $state failed!"
@@ -978,7 +978,7 @@ do
 done
 
 # OK, let looper_chef_client run normally now.
-rm /tmp/deploying
+rm /var/run/crowbar/deploying
 
 
 # Starting more services

--- a/releases/roxy/master/extra/install-chef.sh
+++ b/releases/roxy/master/extra/install-chef.sh
@@ -370,7 +370,8 @@ echo "$(date '+%F %T %z'): Bringing up Crowbar..."
 # Run chef-client to bring-up crowbar server
 chef_or_die "Failed to bring up Crowbar"
 # Make sure looper_chef_client is a NOOP until we are finished deploying
-touch /tmp/deploying
+mkdir -p /var/run/crowbar
+touch /var/run/crowbar/deploying
 
 post_crowbar_fixups
 
@@ -429,7 +430,7 @@ check_machine_role
 for state in "discovering" "discovered" "hardware-installing" \
     "hardware-installed" "installing" "installed" "readying" "ready"
 do
-    while [[ -f "/tmp/chef-client.lock" ]]; do sleep 1; done
+    while [[ -f "/var/run/crowbar/chef-client.lock" ]]; do sleep 1; done
     printf "$state: "
     crowbar crowbar transition "$FQDN" "$state" || \
         die "Transition to $state failed!"
@@ -442,7 +443,7 @@ do
 done
 
 # OK, let looper_chef_client run normally now.
-rm /tmp/deploying
+rm /var/run/crowbar/deploying
 
 # Spit out a warning message if we managed to not get an IP address
 IPSTR=$(crowbar network show default | parse_node_data -a attributes.network.networks.admin.ranges.admin.start)


### PR DESCRIPTION
crowbar install was hanging because the /var/run/crowbar directory did not exist.

Investigation found that install-chef.sh and install-chef-suse.sh needed to be manually merged from pebbles to roxy.

 releases/roxy/master/extra/install-chef-suse.sh |    8 ++++----
 releases/roxy/master/extra/install-chef.sh      |    7 ++++---
 2 files changed, 8 insertions(+), 7 deletions(-)

Crowbar-Pull-ID: fd641136dd34612ead372063e34243c45f9be356

Crowbar-Release: roxy
