### PR TITLE
Small fix for './dev fetch' [1/1]

### DIFF
--- a/dev
+++ b/dev
@@ -2159,6 +2159,7 @@ fetch_all() {
         die "Cannot create temporary storage for fetch results!"
     fetch_ci_tracking
     debug "Fetching updates:"
+    trap "kill -TERM -$$ && rm -rf $results_dir ; exit 1" INT QUIT
     for d in "$CROWBAR_DIR/barclamps/"* "$CROWBAR_DIR"; do
         [[ -d $d/.git ]] || continue
         if [[ $BADLINK ]]; then


### PR DESCRIPTION
'./dev fetch' will now kill all of its subprocesses when it is interrupted (e.g. SIGINT)

 dev |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: b8a065ff31ee7589a186b5c8c841c779418e87ab

Crowbar-Release: development
