### PR TITLE
Posgresql tweaks for dev - this makes sure to create the databas

### DIFF
--- a/dev
+++ b/dev
@@ -4259,6 +4259,8 @@ clear_test_env() {
     RAILS_ENV=development bundle exec rake db:drop
     echo "Removing Test Directory"
     rm -rf "$CROWBAR_TEST_DIR"; 
+    echo "Restarting DB"
+    sudo service postgresql restart
 }
 
 # Create a new barclamp.


### PR DESCRIPTION
./dev tests server was failing if the database had not been created (./dev tests clear DOES remove it)

Had to add a check to see if there is no database when we check for database changes.

Also, shortened the instructions because they were getting out of date.
