### PR TITLE
Minor install-chef-suse cleanup for pebbles and roxy

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -701,6 +701,11 @@ if [ -n "$CROWBAR_FROM_GIT" ]; then
     knife cookbook upload -o "$d" nagios
     rm -rf "$d"
     $json_edit "$CROWBAR_JSON" -a attributes.crowbar.instances.nagios --raw -v "[ ]"
+
+    # Some barclamps depend on the "pfsdeps" view. Fake it, to make the webui
+    # work for those.
+    install -m 0755 -d /opt/dell/crowbar_framework/app/views/barclamp/git/
+    touch /opt/dell/crowbar_framework/app/views/barclamp/git/_pfsdeps.html.haml
 fi
 
 #

--- a/releases/roxy/master/extra/install-chef-suse.sh
+++ b/releases/roxy/master/extra/install-chef-suse.sh
@@ -701,6 +701,11 @@ if [ -n "$CROWBAR_FROM_GIT" ]; then
     knife cookbook upload -o "$d" nagios
     rm -rf "$d"
     $json_edit "$CROWBAR_JSON" -a attributes.crowbar.instances.nagios --raw -v "[ ]"
+
+    # Some barclamps depend on the "pfsdeps" view. Fake it, to make the webui
+    # work for those.
+    install -m 0755 -d /opt/dell/crowbar_framework/app/views/barclamp/git/
+    touch /opt/dell/crowbar_framework/app/views/barclamp/git/_pfsdeps.html.haml
 fi
 
 #


### PR DESCRIPTION
This contains two minor fixes for the --from-git mode of install-chef-suse.sh
- don't install unneeded java 1.6 packages
- disable nagios barclamp
- install tools required during installation to /opt/dell/bin
- avoid zypper prompts
