### PR TITLE
Add license headers to install-chef-suse.sh and network-json-validator

### DIFF
--- a/releases/pebbles/master/extra/install-chef-suse.sh
+++ b/releases/pebbles/master/extra/install-chef-suse.sh
@@ -1,5 +1,20 @@
 #! /bin/bash -e
 # vim: sw=4 et
+#
+# Copyright 2012-2013, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # This script is called after being installed by the Crowbar RPM from the SUSE
 # Cloud ISO. In this context, it is expected that all other required

--- a/releases/pebbles/master/extra/network-json-validator
+++ b/releases/pebbles/master/extra/network-json-validator
@@ -1,4 +1,18 @@
 #!/usr/bin/ruby
+# Copyright 2013, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'rubygems'
 require 'getoptlong'

--- a/releases/roxy/master/extra/install-chef-suse.sh
+++ b/releases/roxy/master/extra/install-chef-suse.sh
@@ -1,5 +1,20 @@
 #! /bin/bash -e
 # vim: sw=4 et
+#
+# Copyright 2012-2013, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # This script is called after being installed by the Crowbar RPM from the SUSE
 # Cloud ISO. In this context, it is expected that all other required

--- a/releases/roxy/master/extra/network-json-validator
+++ b/releases/roxy/master/extra/network-json-validator
@@ -1,4 +1,18 @@
 #!/usr/bin/ruby
+# Copyright 2013, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 require 'rubygems'
 require 'getoptlong'


### PR DESCRIPTION
We failed to ever add them, so let's fix it.
