### PR TITLE
Only extract archives if they exists in the build [1/1]

### DIFF
--- a/ubuntu-common/build_lib.sh
+++ b/ubuntu-common/build_lib.sh
@@ -193,14 +193,18 @@ final_build_fixups() {
     (   cd "$BUILD_DIR/initrd";
         debug "Adding all nic drivers"
         for udeb in "$IMAGE_DIR/pool/main/l/linux/"nic-*-generic-*.udeb; do
-            ar x "$udeb"
-            tar xzf data.tar.gz
-            rm -rf debian-binary *.tar.gz
+             [[ -f $udeb ]] && {
+                ar x "$udeb"
+                tar xzf data.tar.gz
+                rm -rf debian-binary *.tar.gz
+            } 
         done
         # bnx2x nic drivers require firmware images from the kernel image .deb
-        ar x "$IMAGE_DIR/pool/main/l/linux/"linux-image-*-generic_*.deb
-        tar xjf data.tar.bz2 --wildcards './lib/firmware/*/bnx2x/*'
-        rm -rf debian-binary control.tar.gz data.tar.bz2
+        [[ -f "$IMAGE_DIR/pool/main/l/linux/"linux-image-*-generic_*.deb ]] \
+        && { ar x "$IMAGE_DIR/pool/main/l/linux/"linux-image-*-generic_*.deb
+           tar xjf data.tar.bz2 --wildcards './lib/firmware/*/bnx2x/*'
+           rm -rf debian-binary control.tar.gz data.tar.bz2
+        } 
         # Make sure installing off a USB connected DVD will work
         debug "Adding USB connected DVD support"
         mkdir -p var/lib/dpkg/info


### PR DESCRIPTION
Only extract archives if they exist in the build

 ubuntu-common/build_lib.sh |   16 ++++++++++------
 1 file changed, 10 insertions(+), 6 deletions(-)

Crowbar-Pull-ID: 65f1be85982e0220aa73fb6e2862cbf290b62fc6

Crowbar-Release: roxy
