### PR TITLE
activesupport-3.2.13.gem depend on i18n gem

### DIFF
--- a/releases/roxy/master/extra/install-chef.sh
+++ b/releases/roxy/master/extra/install-chef.sh
@@ -171,7 +171,7 @@ EOF
 # to tell Chef to just look in a specific location for its gems.
 echo "$(date '+%F %T %z'): Arranging for gems to be installed"
 (   cd /tftpboot/gemsite/gems
-    for gem in builder json net-http-digest_auth activesupport i18n \
+    for gem in builder json net-http-digest_auth i18n activesupport \
         daemons bluepill xml-simple libxml-ruby wsman cstruct ; do
         gem install --local --no-ri --no-rdoc $gem-*.gem
     done


### PR DESCRIPTION
so i18n should be installed prior to activesupport. Otherwise it will fail with
Successfully installed activesupport-2.3.18
ERROR:  Error installing activesupport-3.2.13.gem:
        activesupport requires i18n (= 0.6.1, runtime)
Successfully installed i18n-0.6.1
Successfully installed i18n-0.6.5
