### PR TITLE
adding barclamp-heat to roxy/openstack-os-build [1/1]

### DIFF
--- a/releases/roxy/openstack-os-build/barclamp-heat
+++ b/releases/roxy/openstack-os-build/barclamp-heat
@@ -1,0 +1,1 @@
+release/roxy/master


### PR DESCRIPTION
adding barclamp-heat to roxy/openstack-os-build

 releases/roxy/openstack-os-build/barclamp-heat |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 4cf66abc6d9dbc3df8266e2f2908941589242344

Crowbar-Release: roxy
