### PR TITLE
Add support for git tracked metadata.

### DIFF
--- a/build_crowbar.sh
+++ b/build_crowbar.sh
@@ -180,7 +180,7 @@ for cmd in sudo chroot mkisofs ruby curl; do
 	die 1 "Please install $cmd before trying to build Crowbar."
 done
 
-flat_checkout || die "Checkout must be flat before starting build!"
+git_tracked_checkout || flat_checkout || die "Checkout must be flat before starting build!"
 
 # Parse our options.
 while [[ $1 ]]; do

--- a/dev
+++ b/dev
@@ -172,12 +172,11 @@ switch_barclamps_to_build() {
     for bc in "$CROWBAR_DIR/barclamps/"*; do
         bc=${bc##*/}
         new_branch=$(barclamp_branch_for_build "$1" "$bc")
-        current_head=$(in_barclamp "$bc" git symbolic-ref HEAD 2>/dev/null || \
-            in_barclamp "$bc" git rev-parse HEAD)
+        current_head=$(in_barclamp "$bc" get_current_head)
         if [[ $new_branch =~ [0-9a-f]{40} && $new_branch = $current_head ]]; then
             # We want HEAD to be on a raw commit, and it is on the one we want.
             continue
-        elif [[ $current_head = refs/heads/$new_branch ]]; then
+        elif [[ $current_head = $new_branch ]]; then
             # We want HEAD to be on a branch, and it is on the one we want.
             continue
         elif [[ $new_branch = empty-branch ]]; then
@@ -207,16 +206,18 @@ switch_release() {
     local l br bc current_branch new_base rel repo
     local -A barclamps
     new_build="$(current_build)"
-    if build_exists "$1"; then
-        new_build="$1"
-    elif release_exists "$1"; then
-        new_build="$1/${new_build##*/}"
-        if ! build_exists "$new_build"; then
-            debug "Release $1 does not have build $new_build, switching to $1/master instead."
-            new_build="$1/master"
+    if [[ $1 ]]; then
+        if build_exists "$1"; then
+            new_build="$1"
+        elif release_exists "$1"; then
+            new_build="$1/${new_build##*/}"
+            if ! build_exists "$new_build"; then
+                debug "Release $1 does not have build $new_build, switching to $1/master instead."
+                new_build="$1/master"
+            fi
+        else
+            die "$1 is not a release or a build I can switch to!"
         fi
-    elif [[ $1 ]]; then
-        die "$1 is not a release or a build I can switch to!"
     fi
     barclamps_are_clean || \
         die "Crowbar repo must be clean before trying to switch releases!"
@@ -493,14 +494,6 @@ clone_barclamps() {
         github_fork "$(origin_remote)" crowbar || \
             die "Unable to create your fork of Crowbar."
     fi
-}
-
-# Check out a branch, but be quiet about it unless something goes wrong.
-quiet_checkout() {
-    local res=''
-    res=$(git checkout -q "$@" 2>&1) && return
-    echo "$res" >&2
-    return 1
 }
 
 # Update tracking branches for all remotes in a specific repo.
@@ -2627,6 +2620,87 @@ setup() {
     switch_release
 }
 
+# Given a release, find the "best" parent release.  This will only
+# be called if we don't already have metadata recorded for the
+# parent relationship of this release.
+find_best_parent() {
+    # $1 = release to find the "best" parent of.
+    #      If empty, use the release we are currently on.
+    local br distance best_distance ref candidate merge_base release
+    local best_candidates=()
+    if [[ $1 ]]; then
+        release_exists "$1" || \
+            die "find_best_parent: $1 is not a release"
+        release="$1"
+    else
+        release="$(current_release)"
+    fi
+    if candidate=$(parent_release "$release"); then
+        printf "%s\n" "$candidate"
+        return 0
+    elif [[ $release != feature/* ]]; then
+        echo "$release"
+        return 0
+    elif in_repo git_config_has "crowbar.releases.$release.parent"; then
+        set_parent_release "$(get_repo_cfg "crowbar.releases.$release.parent")" "$release"
+        parent_release "$release"
+        return 0
+    fi
+    debug "More than one good candidate for a parent of $release found."
+    debug "Please pick the one you want:"
+    select candidate in $(all_releases) "None of the above"; do
+        case $candidate in
+            'None of the above') die "Aborting.";;
+            '') continue;;
+            *) break;;
+        esac
+    done
+    echo "$candidate" > "$CROWBAR_DIR/releases/$release/parent"
+    in_repo git commit -m "Adding parent for $release" "releases/$release/parent"
+}
+
+
+# Create a new release branch structure based on the current state of the
+# Crowbar repositories.
+cut_release() {
+    local new_branch bc
+
+    [[ $1 ]] || die "cut_release: Please specify a name for the new release"
+
+    # Test to see if release exists.
+    release_exists "$1" && die "cut_release: Name already exists"
+    local can_cut=true
+    new_branch="$(release_branch $1)"
+    current_release=$(current_release)
+    barclamps_are_clean || \
+        die "Crowbar repo must be clean before trying to cut a release!"
+
+    clone_release "$current_release" "$1"
+    for build in $(builds_in_release "$current_release"); do
+        debug "Creating build $build in new release $1"
+        for bc in $(barclamps_from_build "$current_release/$build"); do
+            br="$(barclamp_branch_for_build "$current_release/$build" "$bc")"
+            [[ $br && $br != empty-branch ]] || continue
+            in_barclamp "$bc" git branch -f --no-track "$new_branch" "$br"
+            set_barclamp_branch_for_build "$1/$build" "$bc" "$new_branch"
+        done
+    done
+    [[ $1 = feature/* ]] && \
+        set_parent_release "$1" "$current_release"
+    (cd "$(release_cfg_dir "$1")"; git add .)
+    __release_update
+    if git_managed_cache && ! in_cache branch_exists "$new_branch"; then
+        debug "Creating $new_branch for $1 in the build cache"
+        if in_cache branch_exists "$(release_branch)"; then
+            in_cache git branch "$new_branch" "$(release_branch)"
+        else
+            in_cache git branch "$new_branch" master
+        fi
+    fi
+    debug "$1 created."
+    switch_release "$1"
+}
+
 # Test repository $1 to see if commit $2 is in sync with $3.
 # In this case, "in sync" is defined as:
 #  * $2 and $3 point at the same commit, or
@@ -2649,6 +2723,89 @@ branches_synced() {
     # reachable from $2.  If there are, then the branches are not synced.
     (cd "$1"; [[ ! $(git rev-list "$2..$3") ]] ) && return 0
     return 1
+}
+
+# Erase a release.  Complains if it is not merged into its parent release.
+erase_release() {
+    # $1 = release refix
+    local bc build whine=false current_br parent_br template_br
+    local -A branches
+    [[ $2 ]] && die "erase-feature only takes one argument"
+    [[ $1 = development ]] && die "Cannot erase the development release."
+    release_exists "$1" || die "$1 is not a release we can erase!"
+    [[ $1 = $(current_release) ]] && die "Cannot erase the release you are on!"
+    parent=$(find_best_parent "$1")
+    template_br=$(release_branch "$1")
+    for build in $(builds_in_release "$1"); do
+        if ! build_exists "$parent/$build"; then
+            debug "$build does not exist in $parent release."
+            whine=true
+            continue
+        fi
+        for bc in $(barclamps_from_build "$1/$build"); do
+            if ! __barclamp_exists_in_build "$parent/$build/$bc"; then
+                debug "$barclamp does not exist in $parent/$build"
+                whine=true
+                continue
+            fi
+            current_br=$(barclamp_branch_for_build "$1/$build" "$bc")
+            [[ $current_br && $current_br != empty-branch ]] || continue
+            parent_br=$(barclamp_branch_for_build "$parent/$build" "$bc")
+            if [[ ! $parent_br || $parent_br = empty-branch ]]; then
+                debug "$1/$build/$bc: branch ${release_refs[$bc]} is unique to $1."
+                whine=true
+            fi
+            if [[ $current_br != $template_br ]]; then
+                debug "Barclamp $bc is on $current_br, which is not the expected branch name." \
+                    "We expected it to be on $template_br"
+            fi
+            if ! in_barclamp "$bc" branches_synced . "$parent_br" "$current_br"; then
+                debug "barclamp $bc: $current_br is not merged into $parent_br"
+                whine=true
+            fi
+        done
+    done
+    if [[ $whine = true ]]; then
+        printf "$1 is not merged into $parent.  Really erase? (y/n): " >&2
+        read -n 1
+        [[ $REPLY != 'y' ]] && exit
+    fi
+    debug "Erasing branches for release $1"
+    for bc in $(barclamps_in_release "$1"); do
+        for current_br in $(barclamp_branches_for_release "$1" "$bc"); do
+            in_barclamp "$bc" git branch -D "${current_br}" &>/dev/null
+        done
+    done
+    debug "Erasing metadata for release $1"
+    __kill_release "$1"
+}
+
+# Given a release, show any redundant barclamp declarations.
+# This is intended to help manually clean up release metadata.
+show_duplicate_barclamps() {
+    local release=${1:-$(current_release)} build parent bc
+    local to_remove=()
+    for build in $(builds_in_release "$release"); do
+        build="$release/$build"
+        parent=$(parent_build "$build")
+        [[ $parent ]] || continue
+        local -A barclamps
+        for bc in $(barclamps_in_build "$parent"); do
+            barclamps["$bc"]=parent
+        done
+        for bc in $(barclamps_from_build "$build"); do
+            [[ ${barclamps[$bc]} ]] || continue
+            [[ $(get_barclamp_branch_for_build "$build" "$bc") = \
+                $(get_barclamp_branch_for_build "$parent" "$bc") ]] || continue
+            to_remove+=("$build: $bc")
+        done
+    done
+    if [[ $to_remove ]]; then
+        debug "Release $release has the following redundant barclamp metadata:"
+        printf "%s\n" "${to_remove[@]}" |sort -u
+    else
+        debug "No redundant barclamps in release $release"
+    fi
 }
 
 # Back up any local commits that are not already present on our upstreams,
@@ -2752,11 +2909,11 @@ __pin_release() {
 pin_release() {
     barclamps_are_clean || die "Crowbar must be clean before pinning $1"
     if __pin_release "$@"; then
-        git commit -m "Pinned barclamps in $1 to ${2:-current HEAD}"
+        __release_update "Pinned barclamps in $1 to ${2:-current HEAD}"
         switch_release
         return 0
     else
-        __pin_release_cleanup
+        __release_cleanup
         echo "Could not pin $1 to ${2:-current HEAD}, leaving things unchanged."
         return 1
     fi
@@ -2777,6 +2934,54 @@ unpin_release() {
     fi
     pin_release "$1" "$(build_branch "$build")"
 }
+
+
+# Create a new tagged release based on the current state of the repositories.
+cut_tagged_release() {
+    # $1 = name of the tag.
+    # $2 = build to cut from.
+    # The build we are cutting from would have already been pinned to the tag.
+    release_exists "$1" && die "Cannot cut tagged release $1, it already exists!"
+    build_exists "$2" || die "Cannot cut tagged release, basis build $2 does not exist!"
+    local bc ref f
+    # Start with a clone of the release.
+    clone_release "${2%/*}" "$1"
+    # Add tagged refs for all the barclamps we care about to
+    # the master build in the new release
+    for bc in $(barclamps_in_build "$2"); do
+        ref=$(barclamp_branch_for_build "$2" "$bc")
+        [[ $ref && $ref != empty-branch ]] || continue
+        # We assume that the barclamp tags have already been created.
+        __add_barclamp_to_build "$1/master" "$bc" "$1"
+    done
+    # Make sure we copy down build-specific non-barclamp metadata
+    (
+        cd "$(build_cfg_dir "$1/${2##*/}")"
+        target_dir="$(build_cfg_dir "$1/master")"
+        for f in *; do
+            [[ $f = barclamp-* ]] && continue
+            [[ $f = . || $f = .. || $f = parent ]] && continue
+            cp -aL "$f" "$target_dir"
+        done
+        (cd "$target_dir"; git add .)
+    )
+    # Exterminate all now-unneeded non-master builds
+    local build
+    while read build; do
+        [[ $build = master ]] && continue
+        __kill_build "$1/$build"
+    done < <(__builds_in_release "$1")
+    # Create a new fork in the build cache.
+    if git_managed_cache; then
+        local old_rel_br=$(release_branch "${2%/*}")
+        local rel_br="$(release_branch "$1")"
+        in_cache branch_exists "$old_rel_br" && \
+            in_cache git branch "$rel_br" "$old_rel_br"
+    fi
+    __release_update "Cut tagged release $1"
+    switch_release "$1"
+}
+
 
 # Find branches in barclamps for a given release that are not synced,
 # and show them.
@@ -2905,16 +3110,7 @@ merge_releases() {
             [[ ${current_builds[$build]} ]] || continue
             for bc in $(barclamps_from_build "$rel/$build"); do
                 [[ ${current_barclamps[$bc]} ]] || continue
-                head=$(git symbolic-ref HEAD)
-                if [[ $head != refs/heads/* ]]; then
-                    head=$(git rev-parse HEAD)
-                    if [[ ! $head ]]; then
-                        debug "Barclamp ${repo##*/}: Cannot find head commit."
-                        return 1
-                    fi
-                else
-                    head=${head#refs/heads/}
-                fi
+                head=$(get_current_head)
                 merge_one_release "$bc" "$thisrel/$build" "$rel/$build"
                 res=$?
                 in_barclamp "$bc" git checkout -q -f "${head}"
@@ -2942,16 +3138,7 @@ sync_repo() (
     # Repo is not clean, we will refuse to merge in any case.
     git_is_clean || exit 1
     # Merge upstream branches from our remotes
-    head=$(git symbolic-ref HEAD)
-    if [[ $head != refs/heads/* ]]; then
-        head=$(git rev-parse HEAD)
-        if [[ ! $head ]]; then
-            debug "Barclamp ${repo##*/}: Cannot find head commit."
-            return 1
-        fi
-    else
-        head=${head#refs/heads/}
-    fi
+    head=$(get_current_head)
     while read ref branch; do
         branch=${branch#refs/heads/}
         remote="$(remote_for_branch "$branch")" || continue
@@ -3625,6 +3812,8 @@ flatten_crowbar() {
     crowbar_is_clean && \
         [[ $(in_repo git symbolic-ref HEAD) = refs/heads/master ]] || \
         die "You must be on master to flatten the hierarchy!"
+    git_tracked_checkout && die "Cannot flatten Git tracked metadata"
+    flat_checkout && die "Crowbar is already flattened."
     while read sha ref; do
         # Special case handling for tags.
         # We make releases for them, and have their barclamp markers point to
@@ -3711,6 +3900,41 @@ flatten_crowbar() {
     in_repo git config 'crowbar.build' 'development/master'
     in_repo git commit -m "Added flattened Crowbar metadata."
     switch_release
+}
+
+# Transition from flat metadata to git tracked metadata.
+git_track_crowbar_metadata() {
+    local tmp_metadata="$CROWBAR_DIR/.releases"
+    flat_checkout || die "Crowbar metadata is not flat, cannot convert to git tracked!"
+    rm -rf "$tmp_metadata"
+    mkdir -p "$tmp_metadata"
+    (   cd "$tmp_metadata"
+        git init .
+        git checkout master
+        cat >README.crowbar-metadata <<EOF
+This is the crowbar release metadata tracking repository.
+There is a branch in this repository for each release of Crowbar
+that contains all the metadata for that release and the builds that
+are part of that release.
+EOF
+        git add README.crowbar-metadata
+        git commit -m "Initial commit")
+    local working_release
+    while read working_release; do
+        echo "Adding $working_release to git release tracking repository"
+        cfg_dir="$(release_cfg_dir "$working_release")"
+        (cd "$tmp_metadata"; git checkout master; git checkout -b "$working_release")
+        cp -a "$cfg_dir/"* "$tmp_metadata"
+        (cd "$tmp_metadata"; git add .; git commit -m "Added initial metadata for $working_release")
+    done < <(all_releases)
+    echo "Conversion to git tracked metadata finished."
+    echo "Please run ./dev switch to start using the new git tracked metadata."
+    echo "To remove the flat metadata, perform the following steps:"
+    echo
+    echo "\$ git rm -rf releases"
+    echo "\$ git commit -m \"Removing flat metadata in favor of git-tracked release metadata\""
+    echo
+    echo "After doing this, your releases will be tracked using the git repo based metadata."
 }
 
 # Purge submodule information from the master branch.
@@ -4271,6 +4495,7 @@ DEV_COMMANDS["fetch"]="fetch_all"
 DEV_COMMANDS["fetch-pull-requests"]="fetch_pull_requests_for_remote"
 DEV_COMMANDS["find-parent"]="find_best_parent"
 DEV_COMMANDS["flatten"]="flatten_crowbar"
+DEV_COMMANDS["gitify-meta"]="git_track_crowbar_metadata"
 DEV_COMMANDS["help"]="dev_help"
 DEV_COMMANDS["is_clean"]="crowbar_is_clean"
 DEV_COMMANDS["local-changes"]="find_local_changed_branches_for_release"
@@ -4329,6 +4554,7 @@ DEV_SHORT_HELP["fetch"]="              Fetch updates from configured upstream re
 DEV_SHORT_HELP["fetch-pull-requests"]="Fetch pull request information from a specific remote"
 DEV_SHORT_HELP["find-parent"]="        Find the closest parent of a release or feature."
 DEV_SHORT_HELP["flatten"]="            Flatten the main Crowbar repo branching structure."
+DEV_SHORT_HELP["gitify-meta"]="        Take flattened Crowbar metadata and put it in its own Git repo."
 DEV_SHORT_HELP["help"]="               Show detailed help."
 DEV_SHORT_HELP["is_clean"]="           Test to see if all work is committed."
 DEV_SHORT_HELP["local-changes"]="      Find local changes from upstream for a release"
@@ -4765,6 +4991,8 @@ DEV_LONG_HELP["ci"]="Crowbar Continuous Integration Helper.
     show-intents: Shows all the current and stale intents for a pull request.
     kill-stale-intents: Given a pull request ID, this will kill any stale intents
       that are hanging around and attempt to push them out."
+DEV_LONG_HELP["gitify-meta"]="Translate flattened Crowbar metadata from the releases/
+directory hierarchy, and put it in its own Git repository."
 
 # Verify that we have help for all commands, and exit if we don't.
 for cmd in "${!DEV_COMMANDS[@]}"; do

--- a/flat_metadata.sh
+++ b/flat_metadata.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# This contains library routines for handling flat metadata.
 
 # Test to see if a build exists.
 build_exists() [[ -f $CROWBAR_DIR/releases/$1/barclamp-crowbar || \
@@ -7,16 +8,6 @@ build_exists() [[ -f $CROWBAR_DIR/releases/$1/barclamp-crowbar || \
 __barclamp_exists_in_build() {
     local build=${1%/*} bc=${1##*/}
     [[ -f $CROWBAR_DIR/releases/$build/barclamp-$bc ]]
-}
-
-# Test to see if a barclamp is part of a specific build.
-barclamp_exists_in_build() {
-    __barclamp_exists_in_build "$1" && return 0
-    local build=${1%/*} bc=${1##*/}
-    [[ -L $CROWBAR_DIR/releases/$build/parent ]] || return 1
-    local r=$(readlink "$CROWBAR_DIR/releases/$build/parent")
-    r=${r##*/}
-    barclamp_exists_in_build "${build%/*}/$r/$bc"
 }
 
 # Given a fully specced build, point at its config metadata.
@@ -28,15 +19,6 @@ build_cfg_dir() {
 
 ## Test to see if a given release exists.
 release_exists() [[ -d $CROWBAR_DIR/releases/$1/master ]]
-
-# Get the current release we are working on, which is a function of
-# the currently checked-out branch.
-current_release() {
-    local rel
-    rel=$(current_build) || \
-        die "current_release: Cannot get current build information!"
-    echo "${rel%/*}"
-}
 
 # Given a release, return its config dir.
 release_cfg_dir() {
@@ -83,41 +65,24 @@ parent_build() {
     echo "${p##*releases/}"
 }
 
-# Get or set the proper branch for a barclamp for a build.
-barclamp_branch_for_build() {
+# Get the branch that a barclamp should be checked out to for
+# performing a build.
+get_barclamp_branch_for_build() {
     # $1 = build
     # $2 = barclamp
-    # $3 = (optional) ref to pin the barclamp at.
-    local build=$1 bcfile
-    while [[ true ]]; do
-        __barclamp_exists_in_build "$build/$2" && break
-        build=$(parent_build "$build") || break
-    done
-    if [[ ! $3 ]]; then
-        if [[ $build ]]; then
-            cat "$CROWBAR_DIR/releases/$build/barclamp-$2"
-        else
-            echo "empty-branch"
-        fi
-        return 0
-    elif [[ $build ]]; then
-        bcfile="$CROWBAR_DIR/releases/$build/barclamp-$2"
-        [[ -f $bcfile ]] && \
-            in_barclamp "$2" git rev-parse --verify --quiet "$3" &>/dev/null || return 1
-        echo "$3" > "$bcfile"
-        git add "$bcfile"
-    else
-        return 1
-    fi
+    cat "$CROWBAR_DIR/releases/$1/barclamp-$2"
 }
 
-# Given a build, see what barclamps will go into it.
-barclamps_in_build() {
-    local build bc p
-    build="${1:-$(current_build)}"
-    p="$(parent_build "$build")"
-    [[ $p ]] && barclamps_in_build "$p"
-    barclamps_from_build "$build"
+# Set the branch that a barclamp should be checked out to for
+# performing a build.
+set_barclamp_branch_for_build() {
+    # $1 = build
+    # $2 = barclamp
+    # $3 = commit-ish to pin the barclamp at
+    bcfile="$CROWBAR_DIR/releases/$1/barclamp-$2"
+    [[ -f $bcfile ]] || return 1
+    echo "$3" > "$bcfile"
+    in_repo git add "$bcfile"
 }
 
 # Given a release, return the set of all barclamps that are mentioned for it.
@@ -127,35 +92,11 @@ barclamps_in_release() {
     barclamp_finder "$release" '/barclamp-(.+)$'
 }
 
-# Given a release, find all the builds that are in it.
-builds_in_release() {
-    local release="${1:-$(current_release)}" p build b
-    local -A builds
-    release_exists "$release" || return 1
-    for build in $(barclamp_finder "$release" "releases/.+/([^/]+)/(barclamp-crowbar|parent)$"); do
-        build_exists "$release/$build" || continue
-        p=$(parent_build "$release/$build")
-        if [[ $p && ${builds[$p]} != echoed  ]]; then
-            builds["$release/$build"]="$p"
-        else
-            echo "$build"
-            builds["$release/$build"]="echoed"
-        fi
-    done
-    while [[ true ]]; do
-        b=true
-        for build in "${!builds[@]}"; do
-            p="${builds[$build]}"
-            [[ $p = echoed || ${builds[$p]} != echoed ]] && continue
-            echo "${build##*/}"
-            builds[$build]=echoed
-            b=false
-        done
-        [[ $b = true ]] && break
-    done
+__builds_in_release() {
+    barclamp_finder "$1" "releases/.+/([^/]+)/(barclamp-crowbar|parent)\$"
 }
 
-# Return all the barclamps that a members of any release.
+# Return all the barclamps that are members of any release.
 all_barclamps() {
     local bc
     local -A barclamps
@@ -178,219 +119,59 @@ __switch_release_helper() {
     done
 }
 
+# Get the parent release for the current release
+parent_release() {
+    release="${1:-$(current_release)}"
+    [[ -f $CROWBAR_DIR/releases/$release/parent ]] || return 1
+    cat "$CROWBAR_DIR/releases/$release/parent"
+}
+
+# Set release $2 to be the parent of $1
+set_parent_release() {
+    echo "$2" > "$CROWBAR_DIR/releases/$1/parent"
+    in_repo git commit -m "Making $2 the parent release for $1" "releases/$1/parent"
+}
+
+# Performs any metadata-specific tasks that are needed to commit a
+# release metadata change.
+__release_update() {
+    in_repo git commit -m "${1:-Updating release metadata}" releases
+}
+
 # Performs any metadata-specific tasks that are needed to clean up
 # after a failed pin_release.
-__pin_release_cleanup() {
+__release_cleanup() {
     in_repo git rm -r --cached releases/
     in_repo git checkout HEAD -- releases
 }
 
-###
-# The functions below are lifted straight out of the dev tool.
-# They will need to be refactored into devtool-specific and metadata-specific
-# parts once I start writing the git-tracked-metadata library.
-### 
-
-# Given a release, find the "best" parent release.  This will only
-# be called if we don't already have metadata recorded for the
-# parent relationship of this release.
-find_best_parent() {
-    # $1 = release to find the "best" parent of.
-    #      If empty, use the release we are currently on.
-    local br distance best_distance ref candidate merge_base release
-    local best_candidates=()
-    if [[ $1 ]]; then
-        release_exists "$1" || \
-            die "find_best_parent: $1 is not a release"
-        release="$1"
-    else
-        release="$(current_release)"
-    fi
-    if [[ -f $CROWBAR_DIR/releases/$release/parent ]]; then
-        cat "$CROWBAR_DIR/releases/$release/parent"
-        return 0
-    elif [[ $release != feature/* ]]; then
-        echo "$release"
-        return 0
-    elif in_repo git_config_has "crowbar.releases.$release.parent"; then
-        get_repo_cfg "crowbar.releases.$release.parent" | \
-            tee "$CROWBAR_DIR/releases/$release/parent"
-        in_repo git config --unset "crowbar.releases.$release.parent"
-        in_repo git commit -m "Adding parent for $release" "releases/$release/parent"
-        return 0
-    fi
-    debug "More than one good candidate for a parent of $release found."
-    debug "Please pick the one you want:"
-    select candidate in $(all_releases) "None of the above"; do
-        case $candidate in
-            'None of the above') die "Aborting.";;
-            '') continue;;
-            *) break;;
-        esac
-    done
-    echo "$candidate" > "$CROWBAR_DIR/releases/$release/parent"
-    in_repo git commit -m "Adding parent for $release" "releases/$release/parent"
+# Clone release $1 to $2
+clone_release() {
+    mkdir -p "$CROWBAR_DIR/releases/$2"
+    cp -ap "$CROWBAR_DIR/releases/$1/." \
+        "$CROWBAR_DIR/releases/$2/."
+    in_repo git add "releases/$2/"
 }
 
-
-# Create a new release branch structure based on the current state of the
-# Crowbar repositories.
-cut_release() {
-    local new_branch bc
-
-    [[ $1 ]] || die "cut_release: Please specify a name for the new release"
-
-    # Test to see if release exists.
-    release_exists "$1" && die "cut_release: Name already exists"
-    local can_cut=true
-    new_branch="$(release_branch $1)"
-    current_release=$(current_release)
-    barclamps_are_clean || \
-        die "Crowbar repo must be clean before trying to cut a release!"
-
-    mkdir -p "$CROWBAR_DIR/releases/$1"
-    cp -ap "$CROWBAR_DIR/releases/$current_release/." \
-        "$CROWBAR_DIR/releases/$1/."
-    for build in $(builds_in_release "$current_release"); do
-        debug "Creating build $build in new release $1"
-        for bc in $(barclamps_from_build "$current_release/$build"); do
-            br="$(barclamp_branch_for_build "$current_release/$build" "$bc")"
-            [[ $br && $br != empty-branch ]] || continue
-            in_barclamp "$bc" git branch -f --no-track "$new_branch" "$br"
-            echo "$new_branch" > "$CROWBAR_DIR/releases/$1/$build/barclamp-$bc"
-        done
-    done
-    [[ $1 = feature/* ]] && \
-        echo "$(current_release)" > "$CROWBAR_DIR/releases/$1/parent"
-    {   in_repo git add "releases/$1"
-        in_repo git commit -m "Added metadata for new release $1"
-    } &>/dev/null
-    if git_managed_cache && ! in_cache branch_exists "$new_branch"; then
-        debug "Creating $new_branch for $1 in the build cache"
-        if in_cache branch_exists "$(release_branch)"; then
-            in_cache git branch "$new_branch" "$(release_branch)"
-        else
-            in_cache git branch "$new_branch" master
-        fi
-    fi
-    debug "$1 created."
-    debug "You can switch to it with $0 switch $1"
+# Kill metadata for a release.  Should only be called by erase_release,
+__kill_release() {
+    # $1 = release to kill.
+    in_repo git rm -rf "releases/$1"
+    in_repo rm -rf "releases/$1"
+    in_repo git commit -m "Erasing release $1"
 }
 
-# Create a new tagged release based on the current state of the repositories.
-cut_tagged_release() {
-    # $1 = name of the tag.
-    # $2 = build to cut from.
-    # The build we are cutting from whould have already been pinned to the tag.
-    release_exists "$1" && die "Cannot cut tagged release $1, it already exists!"
-    build_exists "$2" || die "Cannot cut tagged release, basis build $2 does not exist!"
-    local bc ref f
-    mkdir -p "$CROWBAR_DIR/releases/$1/master"
-    for bc in $(barclamps_in_build "$2"); do
-        ref=$(barclamp_branch_for_build "$2" "$bc")
-        [[ $ref && $ref != empty-branch ]] || continue
-        # We assume that the barclamp tags have already been created.
-        echo "$1" > "$CROWBAR_DIR/releases/$1/master/barclamp-$bc"
-    done
-    for f in "$CROWBAR_DIR/releases/$2/"*; do
-        f=${f##*/$2/}
-        [[ $f = barclamp-* ]] && continue
-        [[ $f = . || $f = .. || $f = parent ]] && continue
-        cp -a "$CROWBAR_DIR/releases/$2/$f" \
-            "$CROWBAR_DIR/releases/$1/master"
-    done
-    if git_managed_cache; then
-        local old_rel_br=$(release_branch "${2%/*}")
-        local rel_br="$(release_branch "$1")"
-        in_cache branch_exists "$old_rel_br" && \
-            in_cache git branch "$rel_br" "$old_rel_br"
-    fi
-    in_repo git add "releases/$1"
-    in_repo git commit -m "Cut tagged release $1"
+# Add a barclamp to a build.
+__add_barclamp_to_build() {
+    # $1 = build
+    # $2 = barclamp
+    # $3 = commit-ish to use for barclamp in this build.
+    echo "$3" > "$CROWBAR_DIR/releases/$1/barclamp-$2"
+    in_repo git add "releases/$1/barclamp-$2"
 }
 
-# Erase a release.  Complains if it is not merged into its parent release.
-erase_release() {
-    # $1 = release refix
-    local bc build whine=false current_br parent_br template_br
-    local -A branches
-    [[ $2 ]] && die "erase-feature only takes one argument"
-    [[ $1 = development ]] && die "Cannot erase the development release."
-    release_exists "$1" || die "$1 is not a release we can erase!"
-    parent=$(find_best_parent "$1")
-    template_br=$(release_branch "$1")
-    for build in $(builds_in_release "$1"); do
-        if ! [[ -d $CROWBAR_DIR/releases/$parent/$build ]]; then
-            debug "$build does not exist in $parent release."
-            whine=true
-            continue
-        fi
-        for bc in $(barclamps_from_build "$1/$build"); do
-            if ! __barclamp_exists_in_build "$parent/$build/$bc"; then
-                debug "$barclamp does not exist in $parent/$build"
-                whine=true
-                continue
-            fi
-            current_br=$(barclamp_branch_for_build "$1/$build" "$bc")
-            [[ $current_br && $current_br != empty-branch ]] || continue
-            parent_br=$(barclamp_branch_for_build "$parent/$build" "$bc")
-            if [[ ! $parent_br || $parent_br = empty-branch ]]; then
-                debug "$1/$build/$bc: branch ${release_refs[$bc]} is unique to $1."
-                whine=true
-            fi
-            if [[ $current_br != $template_br ]]; then
-                debug "Barclamp $bc is on $current_br, which is not the expected branch name." \
-                    "We expected it to be on $template_br"
-            fi
-            if ! in_barclamp "$bc" branches_synced . "$parent_br" "$current_br"; then
-                debug "barclamp $bc: $current_br is not merged into $parent_br"
-                whine=true
-            fi
-        done
-    done
-    if [[ $whine = true ]]; then
-        printf "$1 is not merged into $parent.  Really erase? (y/n): " >&2
-        read -n 1
-        [[ $REPLY != 'y' ]] && exit
-    fi
-    debug "Erasing branches for release $1"
-    for bc in $(barclamps_in_release "$1"); do
-        for current_br in $(barclamp_branches_for_release "$1" "$bc"); do
-            in_barclamp "$bc" git branch -D "${current_br}" &>/dev/null
-        done
-    done
-    debug "Erasing metadata for release $1"
-    {   in_repo git rm -rf "releases/$1"
-        in_repo rm -rf "releases/$1"
-        in_repo git commit -m "Erasing release $1"
-    } &>/dev/null
-}
-
-# Given a release, show any redundant barclamp declarations.
-# This is intended to help manually clean up release metadata.
-show_duplicate_barclamps() {
-    local release=${1:-$(current_release)} build parent bc
-    local to_remove=()
-    for build in $(builds_in_release "$release"); do
-        build="$release/$build"
-        parent=$(parent_build "$build")
-        [[ $parent ]] || continue
-        local -A barclamps
-        for bc in $(barclamps_in_build "$parent"); do
-            barclamps["$bc"]=parent
-        done
-        for bc in $(barclamps_from_build "$build"); do
-            if [[ ${barclamps[$bc]} ]] && diff -q \
-                "$CROWBAR_DIR/releases/$build/barclamp-$bc" \
-                "$CROWBAR_DIR/releases/$parent/barclamp-$bc" &>/dev/null; then
-                to_remove+=("releases/$build/barclamp-$bc")
-            fi
-        done
-    done
-    if [[ $to_remove ]]; then
-        debug "Release $release has the following redundant barclamp metadata:"
-        echo "${to_remove[*]}"
-    else
-        debug "No redundant barclamps in release $release"
-    fi
+# Kill a build.
+__kill_build() {
+    in_repo git rm -rf "releases/$1"
+    in_repo rm -rf "releases/$1"
 }

--- a/git_tracked_metadata.sh
+++ b/git_tracked_metadata.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# This contains library routines for handling git tracked metadata.
+
+# Helper for running commands in the metadata repository.
+in_meta() ( cd "$CROWBAR_DIR/.releases" && "$@" )
+meta_file_probe() {
+    in_meta branch_exists "$1" || return 1
+    local mode type sha name
+    read mode type sha name < <(in_meta git ls-tree --full-tree -r "$1" "$2")
+    [[ $sha && $type = blob ]]
+}
+
+# git_cat_file, but specialized for working in the metadata repo.
+meta_cat_file() {
+    meta_file_probe "$1" "$2" || return 1
+    git_cat_file "$CROWBAR_DIR/.releases" "$1" "$2"
+}
+
+# Test it see if $1 is a release.
+release_exists() {
+    meta_file_probe "$1" master/barclamp-crowbar
+}
+
+# test to see if $1 is a build.
+build_exists() {
+    local build=${1##*/} rel=${1%/*}
+    meta_file_probe "$rel" "$build/parent" || \
+        meta_file_probe "$rel" "$build/barclamp-crowbar"
+}
+
+__barclamp_exists_in_build() {
+    local bc="${1##*/}" __buildparts="${1%/*}"
+    local build="${__buildparts##*/}" rel="${__buildparts%/*}"
+    meta_file_probe "$rel" "$build/barclamp-$bc"
+}
+
+build_cfg_dir() {
+    local d="${1:-$(current_build)}"
+    build_exists "$d" || return 1
+    echo "$CROWBAR_DIR/.releases/${d##*/}"
+}
+
+release_cfg_dir() {
+    local d="${1:-$(current_release)}"
+    release_exists "$d" || return 1
+    echo "$CROWBAR_DIR/.releases"
+}
+
+# Find all barclamps matching a given RE in a specific release.
+# Internal to git_tracked_metadata.sh
+barclamp_finder() {
+    # $1 = release to look in.
+    # $2 = Regex to match against.
+    # $3 = Match in the RE to return.  Defaults to 1.
+    local name_re='^[^/]+/(parent|barclamp-.+)$'
+    local mode type sha name
+    while read mode type sha name; do
+        [[ $sha && $type = blob && $name =~ $name_re ]] || continue
+        [[ $name =~ $2 ]] || continue
+        printf "%s\n" "${BASH_REMATCH[${3:-1}]}"
+    done < <(in_meta git ls-tree --full-tree -r "$1") |sort -u
+}
+
+builds_for_barclamp_in_release() {
+    release_exists "$2" || die "No such release $2!"
+    barclamp_finder "$2" "([^/]+)/barclamp-$1"
+}
+
+barclamps_from_build() {
+    local d="${1:-$(current_build)}"
+    local build="${d##*/}" rel="${d%/*}"
+    barclamp_finder "$rel" "$build/barclamp-(.+)\$"
+}
+
+parent_build() {
+    build_exists "$1" || return 1
+    local build="${1##*/}" rel="${1%/*}" parent
+    parent=$(meta_cat_file "$rel" "$build/parent") || return 1
+    echo "$rel/${parent##*/}"
+}
+
+get_barclamp_branch_for_build() {
+    local build="${1##*/}" rel="${1%/*}"
+    meta_cat_file "$rel" "$build/barclamp-$2"
+}
+
+set_barclamp_branch_for_build() (
+    local build="${1##*/}" rel="${1%/*}" res=0
+    cd "$CROWBAR_DIR/.releases"
+    quiet_checkout "$rel" || return 1
+    local bcfile="$build/barclamp-$2"
+    echo "$3" > "$bcfile"
+    git add "$bcfile"
+)
+
+barclamps_in_release() {
+    local release="${1:-$(current_release)}"
+    release_exists "$release" || return 1
+    barclamp_finder "$release" '/barclamp-(.+)$'
+}
+
+__builds_in_release() {
+    barclamp_finder "$1" '^([^/]+)/(barclamp-crowbar|parent)$'
+}
+
+all_releases() {
+    local sha ref
+    while read sha ref; do
+        [[ $ref = refs/heads/* ]] || continue
+        ref=${ref#refs/heads/}
+        release_exists "$ref" || continue
+        printf "%s\n" "$ref"
+    done < <(in_meta git show-ref --heads)
+}
+
+all_barclamps() {
+    local rel
+    while read rel; do
+        barclamps_in_release "$rel"
+    done < <(all_releases) |sort -u
+}
+
+__switch_release_helper() {
+    # $1 = the build we are switching to.
+    local l build="${1##*/}" rel="${1%/*}"
+    in_repo quiet_checkout master
+    in_meta quiet_checkout "$rel"
+    for l in change-image extra; do
+        [[ $(in_repo readlink -f $l) = ".releases/$build/$l" ]] && continue
+        in_repo rm -f "$l"
+        in_repo ln -sf ".releases/$build/$l" "$l"
+    done
+}
+
+__release_update() { in_meta git commit -m "${1:-Updating release metadata}"; }
+
+__release_cleanup() { in_meta git reset --hard; }
+
+parent_release() {
+    release="${1:-$(current_release)}"
+    meta_cat_file "$release" "parent"
+}
+
+set_parent_release() (
+    release_exists "$1" || die "Release $1 does not exist, cannot set its parent!"
+    cd "$CROWBAR_DIR/.releases"
+    local head=$(get_current_head)
+    quiet_checkout "$1"
+    echo "$2" > parent
+    git add parent
+    git commit -m "Setting parent of $1 to $2"
+    quiet_checkout "$head"
+)
+
+clone_release(){
+    in_meta git branch -f "$2" "$1"
+    in_meta quiet_checkout "$2"
+}
+
+__kill_release() (
+    cd "$CROWBAR_DIR/.releases"
+    quiet_checkout master
+    git branch -D "$1"
+)
+
+# The next two assume that you already have the metadata checked out to the
+# proper release.
+__add_barclamp_to_build() (
+    cd "$CROWBAR_DIR/.releases"
+    local build="${1##*/}" rel="${1%/*}"
+    echo "$3" > "$build/barclamp-$2"
+    git add "$build/barclamp-$2"
+)
+
+__kill_build() {
+    local build="${1##*/}" rel="${1%/*}"
+    in_meta git rm -rf "$build"
+    in_meta rm -rf "$build"
+}


### PR DESCRIPTION
This is intended to let other people test drive using git tracked
metadata.  Support is not complete -- the dev tool still needs to be
updated to pull in and track the metadata tracking repo like it tracks
the barclamps, and support needs to be added to ./dev setup to start
pulling in the metadata tracking repo.
