### PR TITLE
Adding ceph barclamp [1/1]

### DIFF
--- a/releases/roxy/openstack-os-build/barclamp-ceph
+++ b/releases/roxy/openstack-os-build/barclamp-ceph
@@ -1,0 +1,1 @@
+release/roxy/master


### PR DESCRIPTION
Added Ceph barclamp to release/roxy/master 

 releases/roxy/openstack-os-build/barclamp-ceph |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 37f8fdebfaa2de891f6561c41c86667bd9d48076

Crowbar-Release: roxy
