### PR TITLE
Fixed locale addition extraction if the crowbar.yml key doesn't exist

### DIFF
--- a/releases/roxy/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/roxy/master/extra/barclamp_mgmt_lib.rb
@@ -257,7 +257,7 @@ end
 
 #merges localizations from config into the matching translation files
 def merge_i18n(yaml)
-  locales = yaml['locale_additions']
+  locales = yaml['locale_additions'] || {}
   locales.each do |key, value|
     #translation file (can be multiple)
     f = File.join CROWBAR_PATH, 'config', 'locales', "#{key}.yml"


### PR DESCRIPTION
As you can see within the title and the code i've added an alternative if the locale_additions key doesn't exist so that we don't get any error if we remove the locale additions from crowbar.yml.
