### PR TITLE
Fix early script abort

### DIFF
--- a/releases/roxy/master/extra/install-chef-suse.sh
+++ b/releases/roxy/master/extra/install-chef-suse.sh
@@ -768,7 +768,8 @@ knife node run_list add "$FQDN" role["$NODE_ROLE"]
 chef-client
 
 # Create session store database
-rm -f /opt/dell/crowbar_framework/db/{migrate/,production.sqlite3,schema.rb}
+rm -rf /opt/dell/crowbar_framework/db/migrate
+rm -f /opt/dell/crowbar_framework/db/{production.sqlite3,schema.rb}
 su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production rake db:sessions:create && RAILS_ENV=production rake db:migrate"
 
 # OOC, what, if anything, is responsible for starting rainbows/crowbar under bluepill?


### PR DESCRIPTION
migrate/ is a directory, rm -f does not work on it unless
it would be empty (which it isn't)
