### PR TITLE
Feature: this feature add cache functionality for pip requirements for barclamps

### DIFF
--- a/build_lib.sh
+++ b/build_lib.sh
@@ -1265,7 +1265,7 @@ do_crowbar_build() {
             printf "\e[0G\e[2K%s" "$bc"
             $checker "$bc" || continue
             echo
-            [[ $ALLOW_CACHE_UPDATE = true || $cache = git_repo ]] || {
+            [[ $ALLOW_CACHE_UPDATE = true || $cache = git_repo || $cache = pip ]] || {
                 echo "Need up update $cache cache for $bc, but updates are disabled."
                 echo "Please rerun the build with the --update-cache option."
                 exit 1


### PR DESCRIPTION
This feature allow caching pips from crowbar.yml for barclamps.

If in crowbar.yml of barclamp contain directive "pips" with "requrments", after caching in $CACHE_DIR/barclamps/<barclamp>/files/pip_cache you will see all pips.
