### PR TITLE
Add restart option to barclamp_install

### DIFF
--- a/releases/roxy/master/extra/barclamp_install.rb
+++ b/releases/roxy/master/extra/barclamp_install.rb
@@ -26,7 +26,7 @@ opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
   [ '--debug', '-d', GetoptLong::NO_ARGUMENT ],
   [ '--force', '-f', GetoptLong::NO_ARGUMENT ],
-  [ '--restart-crowbar-app', '-a', GetoptLong::NO_ARGUMENT ],
+  [ '--restart-crowbar', '-r', GetoptLong::NO_ARGUMENT ],
   [ '--rpm', GetoptLong::NO_ARGUMENT ]
 )
 
@@ -51,7 +51,7 @@ opts.each do |opt, arg|
     force_install = true
     when "--rpm"
     from_rpm = true
-    when "--restart-crowbar-app"
+    when "--restart-crowbar"
     restart_crowbar_app = true
   end
 end

--- a/releases/roxy/master/extra/barclamp_uninstall.rb
+++ b/releases/roxy/master/extra/barclamp_uninstall.rb
@@ -25,7 +25,7 @@ require 'getoptlong'
 opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
   [ '--debug', '-d', GetoptLong::NO_ARGUMENT ],
-  [ '--restart-crowbar-app', '-a', GetoptLong::NO_ARGUMENT ],
+  [ '--restart-crowbar', '-r', GetoptLong::NO_ARGUMENT ],
   [ '--rpm', GetoptLong::NO_ARGUMENT ]
 )
 
@@ -47,7 +47,7 @@ opts.each do |opt, arg|
     debug "debug mode is enabled"
     when "--rpm"
     from_rpm = true
-    when "--restart-crowbar-app"
+    when "--restart-crowbar"
     restart_crowbar_app = true
   end
 end


### PR DESCRIPTION
Whenever installing a barclamp to a crowbar app (running in production
mode), a restart is required so that the barclamp code is fully loaded
and can be actually used.

This patch adds an option (off by default) to barclamp_install to
restart the crowbar service after installation.
