### PR TITLE
Allow the provisioner to handle building Sledgehammer. [3/3]

### DIFF
--- a/build_crowbar.sh
+++ b/build_crowbar.sh
@@ -58,15 +58,8 @@ VERBOSE=true
 
 [[ $ALLOW_CACHE_UPDATE ]] || ALLOW_CACHE_UPDATE=true
 
-# Location to store .iso images that we use in the build process.
-# These are usually OS install DVDs that we will stage Crowbar on to.
-[[ $ISO_LIBRARY ]] || ISO_LIBRARY="$CACHE_DIR/iso"
-
 # This is the location that we will save the generated .iso to.
 [[ $ISO_DEST ]] || ISO_DEST="$PWD"
-
-# Directory that holds our Sledgehammer PXE tree.
-[[ $SLEDGEHAMMER_PXE_DIR ]] || SLEDGEHAMMER_PXE_DIR="$CACHE_DIR/tftpboot"
 
 # Location of the Crowbar checkout we are building from.
 [[ $CROWBAR_DIR ]] || CROWBAR_DIR="${0%/*}"
@@ -95,6 +88,13 @@ unset CROWBAR_BUILD_PID
 # Source our common build functions
 . "$CROWBAR_DIR/build_lib.sh" || exit 1
 . "$CROWBAR_DIR/test_lib.sh" || exit 1
+
+# Location to store .iso images that we use in the build process.
+# These are usually OS install DVDs that we will stage Crowbar on to.
+[[ $ISO_LIBRARY ]] || ISO_LIBRARY="$CACHE_DIR/iso"
+
+# Directory that holds our Sledgehammer PXE tree.
+[[ $SLEDGEHAMMER_PXE_DIR ]] || SLEDGEHAMMER_PXE_DIR="$CACHE_DIR/tftpboot"
 
 # Make sure that we actually know how to build the ISO we were asked to
 # build.  If we do not, print a helpful error message.

--- a/build_sledgehammer.sh
+++ b/build_sledgehammer.sh
@@ -66,6 +66,13 @@ mkdir -p "$CACHE_DIR" "$IMAGE_DIR" "$CHROOT"
     die "$CROWBAR_DIR is not a git checkout of Crowbar!"
 export CROWBAR_DIR
 
+# If the provisioner provides a build_sledgehammer,sh, use it instead.
+if [[ -x $CROWBAR_DIR/barclamps/provisioner/build_sledgehammer.sh ]]; then
+    (cd "$CROWBAR_DIR/barclamps/provisioner/"
+        ./build_sledgehammer.sh)
+    exit $?
+fi
+
 # Directory that holds our Sledgehammer PXE tree.
 [[ $SLEDGEHAMMER_PXE_DIR ]] || SLEDGEHAMMER_PXE_DIR="$CACHE_DIR/tftpboot"
 


### PR DESCRIPTION
This pull request series allows the Crowbar build system to let the
provisioner handle building Sledgehammer instead of forcing the
top-level build machinery to have sole responsibility for building
it.  This makes it possible for releases to have their own versions of
Sledgehammer instead of forcing all releases to assume they are
talking to the same Sledgehammer image.

The first use of this functionality is also included in this pull
request, which changes how Sledgehammer operates for CB 2.0:
- Remove some unneeded bundled packages (Chef and friends,
  specifically)
- Remove our reliance on NFS.
- Change the default password for the root user on Sledgehammer to "crowbar"
  
  build_crowbar.sh      | 14 +++++++-------
  build_lib.sh          | 25 +++++++++++++------------
  build_sledgehammer.sh |  7 +++++++
  3 files changed, 27 insertions(+), 19 deletions(-)

Crowbar-Pull-ID: 1ec7113e8c740a01d2d6b4b05f18567143c353b1

Crowbar-Release: development
