### PR TITLE
CB 2.0: Display the version string again. [2/2]

### DIFF
--- a/releases/development/master/extra/install-crowbar-native.sh
+++ b/releases/development/master/extra/install-crowbar-native.sh
@@ -99,6 +99,11 @@ if [[ $OS != suse ]]; then
     fi
 fi
 
+[[ -f /opt/dell/crowbar_framework/.version ]] || {
+    mkdir -p /opt/dell/crowbar_framework
+    ln -sf "$DVD_PATH/dell/Version" /opt/dell/crowbar_framework/.version
+}
+
 fqdn_re='^[0-9a-zA-Z.-]+$'
 # Make sure there is something of a domain name
 export DOMAINNAME=${FQDN#*.}


### PR DESCRIPTION
Once upon a time, we displayed a meaningful version string in the UI.
It bitrotted away.  This restores it to something vaguely useful.

 releases/development/master/extra/install-crowbar-native.sh | 5 +++++
 1 file changed, 5 insertions(+)

Crowbar-Pull-ID: d182851598ec5c2e583c9397ff2dd97229a61b2a

Crowbar-Release: development
