### PR TITLE
Set default rabbitmq configuration

### DIFF
--- a/releases/roxy/master/extra/install-chef-suse.sh
+++ b/releases/roxy/master/extra/install-chef-suse.sh
@@ -606,6 +606,17 @@ fi
 
 echo_summary "Starting required services"
 
+# Write default RabbitMQ configuration (if the package doesn't provide one).
+if [ ! -f /etc/rabbitmq/rabbitmq.config ] ; then
+    cat << EOF > /etc/rabbitmq/rabbitmq.config
+[
+ {rabbit,
+  [{disk_free_limit, 50000000}]
+ }
+].
+EOF
+fi
+
 chkconfig rabbitmq-server on
 ensure_service_running rabbitmq-server '^Node .+ with Pid [0-9]+: running'
 


### PR DESCRIPTION
Especially set disk_free_limit to 50MB.  Otherwise defaults to 1GB which may be too much for virtual environments. Changes will only take effect after a restart since there is no way to reload configuration at runtime.
