### PR TITLE
fix NameError: @@debug is not initialized if debug mode is off

### DIFF
--- a/releases/roxy/master/extra/barclamp_install.rb
+++ b/releases/roxy/master/extra/barclamp_install.rb
@@ -44,7 +44,7 @@ opts.each do |opt, arg|
     when "--help"
     usage
     when "--debug"
-    @@debug = true
+    ENV['DEBUG'] = 'true'
     debug "debug mode is enabled"
     when "--force"
     force_install = true
@@ -187,7 +187,7 @@ barclamps.values.sort_by{|v| v[:order]}.each do |bc|
       raise e
     end
   rescue StandardError => e
-    if @@debug
+    if ENV['DEBUG'] === 'true'
       debug "temporary directory #{tmpdir} will be left for debugging if it exists"
     else
       rm_tmpdir(tmpdir)

--- a/releases/roxy/master/extra/barclamp_uninstall.rb
+++ b/releases/roxy/master/extra/barclamp_uninstall.rb
@@ -41,7 +41,7 @@ opts.each do |opt, arg|
     when "--help"
     usage
     when "--debug"
-    @@debug = true
+    ENV['DEBUG'] = 'true'
     debug "debug mode is enabled"
     when "--rpm"
     from_rpm = true


### PR DESCRIPTION
/opt/dell/bin/barclamp_install.rb:190: uninitialized class variable @@debug in
Object (NameError)
from /opt/dell/bin/barclamp_install.rb:123:in `each'
from /opt/dell/bin/barclamp_install.rb:123
