### PR TITLE
Explicitly define @@debug in barclamp_* scripts

### DIFF
--- a/releases/roxy/master/extra/barclamp_install.rb
+++ b/releases/roxy/master/extra/barclamp_install.rb
@@ -38,6 +38,7 @@ end
 
 force_install = false
 from_rpm = false
+@@debug = false
 
 opts.each do |opt, arg|
   case opt

--- a/releases/roxy/master/extra/barclamp_uninstall.rb
+++ b/releases/roxy/master/extra/barclamp_uninstall.rb
@@ -35,6 +35,7 @@ def usage()
 end
 
 from_rpm = false
+@@debug = false
 
 opts.each do |opt, arg|
   case opt


### PR DESCRIPTION
If --debug option is not passed and barclamp_\* script fails, the
previous error is masqued by exception about @@debug being undefined.
