### PR TITLE
Updated with namenode definition

### DIFF
--- a/releases/hadoop-2.4/hadoop-build/network-hadoop-10Gteam-admin.json
+++ b/releases/hadoop-2.4/hadoop-build/network-hadoop-10Gteam-admin.json
@@ -94,7 +94,15 @@
             }
           }
         },
-         {
+       {
+        "pattern": "team/.*/.*namenode",
+        "conduit_list": { 
+           "prod": {
+            "if_list": [ "10g1", "10g2" ],
+            "team_mode": 6
+               }
+           }
+        },         {
         "pattern": "team/.*/.*filernode",
         "conduit_list": { 
            "prod": {


### PR DESCRIPTION
Discovered that the teaming json for 10G does not have a namenode definition.  
