### PR TITLE
Comment lines in requirements.txt files

### DIFF
--- a/pip-bundler.py
+++ b/pip-bundler.py
@@ -59,7 +59,7 @@ class Bundler:
 
             if package_requires is not None:
                 for req in open(package_requires):
-                    if len(req.strip()) is 0:
+                    if len(req.strip()) is 0 or req.strip().startswith('#'):
                         continue
                     dependencies.append(req.strip())
 


### PR DESCRIPTION
Some requirements.txt files (e.g., pyudev's) contain comment lines starting with #.
These lines aren't correctly skipped by the pip-bundler.py script which tries to resolve non-existant dependencies.

This fix should solve the issue (tested on Ubuntu).
