### PR TITLE
Cleanup network ranges

### DIFF
--- a/releases/stoney/master/extra/network-json-validator
+++ b/releases/stoney/master/extra/network-json-validator
@@ -23,10 +23,10 @@ REQUIRED_NETWORKS = {
   'admin' => ['admin', 'dhcp', 'host', 'switch'],
   'bmc' => ['host'],
   'bmc_vlan' => ['host'],
-  'nova_fixed' => ['dhcp', 'router'],
+  'nova_fixed' => ['dhcp'],
   'nova_floating' => ['host'],
   'os_sdn' => ['host'],
-  'public' => ['dhcp', 'host'],
+  'public' => ['host'],
   'storage' => ['host']
 }
 


### PR DESCRIPTION
The "router" range for "nova_fixed" and the "dhcp" range for "nova_floating"
are no longer required.
