### PR TITLE
Removed session migration create because it is already present within the migration directory

### DIFF
--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -782,10 +782,6 @@ knife node run_list add "$FQDN" role["$NODE_ROLE"]
 
 chef-client
 
-# Create session store database
-rm -rf /opt/dell/crowbar_framework/db/migrate
-rm -f /opt/dell/crowbar_framework/db/{production.sqlite3,schema.rb}
-
 if [ -n "$CROWBAR_FROM_GIT" ]; then
     # FIXME: This workaround can be removed once rspec packages are available.
     # Until then, remove the rspec related tasks to avoid rake complainig about
@@ -794,7 +790,10 @@ if [ -n "$CROWBAR_FROM_GIT" ]; then
     # installed by default.
     rm -f /opt/dell/crowbar_framework/lib/tasks/rspec.rake
 fi
-su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production rake db:sessions:create && RAILS_ENV=production rake db:migrate"
+
+# Create session store database
+rm -f /opt/dell/crowbar_framework/db/*.sqlite3
+su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production rake db:create db:migrate"
 
 # OOC, what, if anything, is responsible for starting rainbows/crowbar under bluepill?
 ensure_service_running crowbar

--- a/releases/stoney/master/extra/install-chef.sh
+++ b/releases/stoney/master/extra/install-chef.sh
@@ -410,8 +410,8 @@ for role in crowbar deployer-client $NODE_ROLE; do
 done
 
 echo "$(date '+%F %T %z'): Create session store database"
-rm -rf /opt/dell/crowbar_framework/db/{migrate,schema.rb,*.sqlite3}
-su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production rake db:sessions:create db:migrate"
+rm -f /opt/dell/crowbar_framework/db/*.sqlite3
+su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production rake db:create db:migrate"
 
 pre_crowbar_fixups
 


### PR DESCRIPTION
Depends on https://github.com/crowbar/barclamp-crowbar/pull/1045
