### PR TITLE
Removed chef from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 group :development do
   gem 'pry-debugger', '>= 0.2'
 
-  gem 'rb-inotify', ">= 0.9"
-  gem 'guard', ">= 1.8"
+  gem 'rb-inotify', '>= 0.9'
+  gem 'guard', '>= 1.8'
 
   gem 'guard-rsync', 
-    :github => "aspiers/guard-rsync", 
-    :branch => "crowbar"
+    :github => 'aspiers/guard-rsync', 
+    :branch => 'crowbar'
 end


### PR DESCRIPTION
I have removed chef from the global Gemfile as it is not used here
anymore and it just conflicts with the chef version installed by
crowbar.
