### PR TITLE
Use rsync archive mode to install barclamp files

### DIFF
--- a/releases/stoney/master/extra/barclamp_install.rb
+++ b/releases/stoney/master/extra/barclamp_install.rb
@@ -174,7 +174,7 @@ barclamps.values.sort_by{|v| v[:order]}.each do |bc|
         File.exists?("#{target}/sha1sums") and \
         system "/bin/bash -c 'diff -q <(sort \"#{bc[:src]}/sha1sums\") <(sort \"#{target}/sha1sums\")'"
         debug "syncing \"#{bc[:src]}\" directory and \"#{target}\" directory"
-        system "rsync -r \"#{bc[:src]}/\" \"#{target}\""
+        system "rsync -a \"#{bc[:src]}/\" \"#{target}\""
       end
       bc[:src] = target
     end


### PR DESCRIPTION
Using -a will sync symlinks, as e.g. used in the pacemaker barclamp, correctly
when copying files.
