### PR TITLE
Check that /srv/tftpboot/suse-11.3/install is not a symlink

### DIFF
--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -517,6 +517,10 @@ check_repo_content \
     /srv/tftpboot/suse-11.3/install \
     d0bb700ab51c180200995dfdf5a6ade8
 
+if [ -L /srv/tftpboot/suse-11.3/install ]; then
+    die "/srv/tftpboot/suse-11.3/install cannot be a symbolic link"
+fi
+
 check_repo_content \
     Cloud \
     /srv/tftpboot/repos/Cloud \


### PR DESCRIPTION
Using a symlink is not supported for PXE boot, unfortunately.

https://bugzilla.novell.com/show_bug.cgi?id=886196
