### PR TITLE
Reduce flickering caused by the spinner a bit

### DIFF
--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -109,7 +109,7 @@ pipe_show_and_log () {
     if use_dialog; then
         t=$(mktemp)
         cat - > $t
-        dialog --title "$DIALOG_TITLE" --textbox -- $t $(($(wc -l <$t)+4)) 75 >&3
+        dialog --keep-tite --title "$DIALOG_TITLE" --textbox -- $t $(($(wc -l <$t)+4)) 75 >&3
         rm -f $t
         dialog --clear >&3
     fi
@@ -129,7 +129,8 @@ spinner () {
     while [ true ]; do
         local temp=${spinstr#?}
         if use_dialog; then
-            printf "\n%s [%c]" "$msg... " "$spinstr" | dialog --title "$DIALOG_TITLE" \
+            printf "\n%s [%c]" "$msg... " "$spinstr" | dialog \
+                --keep-tite --title "$DIALOG_TITLE" \
                 --keep-window --progressbox 5 70 >&3
         else
             printf "[%c]" "$spinstr" >&3


### PR DESCRIPTION
Normally  dialog  checks  to  see if it is running in an xterm, and in that case
tries to suppress the initialization strings that would make it  switch  to  the
alternate screen.  Switching between the normal and alternate screens is visual-
ly distracting in a script which runs dialog several times.
