### PR TITLE
Stop excessive chef-server log

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -652,6 +652,8 @@ else
     rabbitmqctl add_user chef "$rabbit_chef_password"
     # Update "amqp_pass" in  /etc/chef/server.rb and solr.rb
     sed -i 's/amqp_pass ".*"/amqp_pass "'"$rabbit_chef_password"'"/' /etc/chef/{server,solr}.rb
+    # chef-server is way too verbose in :info, with nothing useful in the log
+    sed -i 's/log_level  *:.*/log_level :warn/' /etc/chef/server.rb
 fi
 
 rabbitmqctl set_permissions -p /chef chef ".*" ".*" ".*"

--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -652,6 +652,8 @@ else
     rabbitmqctl add_user chef "$rabbit_chef_password"
     # Update "amqp_pass" in  /etc/chef/server.rb and solr.rb
     sed -i 's/amqp_pass ".*"/amqp_pass "'"$rabbit_chef_password"'"/' /etc/chef/{server,solr}.rb
+    # chef-server is way too verbose in :info, with nothing useful in the log
+    sed -i 's/log_level  *:.*/log_level :warn/' /etc/chef/server.rb
 fi
 
 rabbitmqctl set_permissions -p /chef chef ".*" ".*" ".*"


### PR DESCRIPTION
The logs grow to ~200MB in a couple of hours when we deploy, because it
logs the full params (eg, full content of node objects) at the info
level. The log is not really useful as it is, so instead, only log at
the warn level.

https://bugzilla.novell.com/show_bug.cgi?id=884550

Workaround mentioned in original upstream bug:
 https://tickets.opscode.com/browse/CHEF-1122
