### PR TITLE
install-chef-suse: Create a /etc/chef/client.rb file on admin server

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -706,9 +706,9 @@ done
 knife node -y bulk delete ".*"
 knife role -y bulk delete ".*"
 
-cat <<EOF
-This can cause warnings about /etc/chef/client.rb missing and
-the run list being empty; they can be safely ignored.
+cat > /etc/chef/client.rb <<EOF
+chef_server_url 'http://$IPv4_addr:4000'
+enable_reporting false
 EOF
 
 chef-client

--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -706,9 +706,9 @@ done
 knife node -y bulk delete ".*"
 knife role -y bulk delete ".*"
 
-cat <<EOF
-This can cause warnings about /etc/chef/client.rb missing and
-the run list being empty; they can be safely ignored.
+cat > /etc/chef/client.rb <<EOF
+chef_server_url 'http://$IPv4_addr:4000'
+enable_reporting false
 EOF
 
 chef-client


### PR DESCRIPTION
We don't have this file, and this creates some warnings/errors:

```
[Mon, 04 Aug 2014 15:24:34 +0200] WARN: *****************************************
[Mon, 04 Aug 2014 15:24:34 +0200] WARN: Did not find config file: /etc/chef/client.rb, using command line options.
[Mon, 04 Aug 2014 15:24:34 +0200] WARN: *****************************************
[...]
[Mon, 04 Aug 2014 15:24:35 +0200] INFO: HTTP Request Returned 404 Not Found: No routes match the request: /reports/nodes/crowbar.site/runs
```

It's trivial to have the minimal config bits that are required to avoid
these.

(Note that we disable reporting as it requires Chef Enterprise)
