### PR TITLE
Install crowbar-openstack before neutron

### DIFF
--- a/releases/stoney/master/extra/install-chef-suse.sh
+++ b/releases/stoney/master/extra/install-chef-suse.sh
@@ -752,8 +752,8 @@ fi
 # in cookbook dependencies)
 #
 for i in crowbar deployer dns ipmi logging network ntp provisioner pacemaker \
-         database rabbitmq keystone swift ceph glance cinder neutron nova \
-         nova_dashboard openstack ; do
+         database rabbitmq openstack keystone swift ceph glance cinder neutron \
+         nova nova_dashboard ; do
     /opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS $BARCLAMP_SRC/$i
 done
 


### PR DESCRIPTION
neutron installation fails because it depends on crowbar-openstack cookbook.
Th error message is:

```
Installing barclamp neutron from /opt/dell/barclamps/neutron
ERROR: /opt/dell/barclamps/neutron knife cookbook upload -o . neutron -V -k /etc/chef/webui.pem -u chef-webui upload failed.  Aborting; examine /var/log/crowbar/barclamp_install/neutron.log for more info.
```

And neutron.log content is:

```
Uploading neutron        [1.0.0]
ERROR: Cookbook neutron depends on cookbook crowbar-openstack version >= 0.0.0,
ERROR: which is not currently being uploaded and cannot be found on the server.
```
