### PR TITLE
Fixed tftpboot symlink check

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -524,8 +524,8 @@ else
         d0bb700ab51c180200995dfdf5a6ade8
 fi
 
-if [ -L $MEDIA ]; then
-    die "$MEDIA cannot be a symbolic link"
+if [[ ! "$(readlink -e ${MEDIA})" =~ ^/srv/tftpboot/.* ]]; then
+    die "$MEDIA must exist and any possible symlinks must not point outside /srv/tftpboot/ directory, as otherwise the PXE server can not access it."
 fi
 
 check_repo_content \


### PR DESCRIPTION
As it is possible to use autofs to mount the medias we need to set
symlinks to the autofs root folder. Now the condition checks if the
symlink is set within the tftpboot root, if it is everything is fine, if
it points outside of the root the installation stops with an error
message.
