### PR TITLE
Moving OpenStack Nova networks to barclamp-neutron (WIP)

### DIFF
--- a/doc/deployguide/introduction.md
+++ b/doc/deployguide/introduction.md
@@ -92,6 +92,7 @@ Public network for nova Virtual Machines
 The nova-network node acts as a router. This must be completely owned by the nova system. 
 nova_floating
 Used for external access to nova virtual machines
+Warning !!! Networks definitions for nova_fixed and nova_floating will be moved to barclamp-neutron
 
 Table 2 Logical Network Definitions
 3.2.2 Changing the network configuration

--- a/releases/development/master/change-image/dell/smoketest
+++ b/releases/development/master/change-image/dell/smoketest
@@ -36,7 +36,7 @@ mkdir -p "$LOGDIR"
 
 if [[ ! -f /opt/dell/.all_nets ]]; then
     touch /opt/dell/.all_nets
-    for n in "public host" "storage host" "nova_fixed router"; do
+    for n in "public host" "storage host"; do
         crowbar network allocate_ip default $(hostname --fqdn) $n
     done
 

--- a/releases/development/master/extra/network-json-validator
+++ b/releases/development/master/extra/network-json-validator
@@ -25,8 +25,6 @@ REQUIRED_NETWORKS = {
   'admin' => ['admin', 'dhcp', 'host', 'switch'],
   'bmc' => ['host'],
   'bmc_vlan' => ['host'],
-  'nova_fixed' => ['dhcp'],
-  'nova_floating' => ['host'],
   'os_sdn' => ['host'],
   'public' => ['host'],
   'storage' => ['host']
@@ -414,20 +412,6 @@ def validate_networks databag
       @networks[name] = net
     rescue Exception => e
       raise "Cannot validate definition for network '#{name}': #{e.to_s}"
-    end
-  end
-
-  if not @networks['public'].subnet_addr_full.include?(@networks['nova_floating'].subnet_addr_full)
-    raise "'nova_floating' network must be a subnetwork of 'public' network"
-  end
-
-  if @networks['public'].use_vlan != @networks['nova_floating'].use_vlan
-    raise "The 'Use VLAN' setting (JSON attribute: 'use_vlan') of the 'nova_floating' and 'public' networks must be the same."
-  end
-
-  if @networks['public'].use_vlan
-    if @networks['public'].vlan != @networks['nova_floating'].vlan
-      raise "'nova_floating' network must have the same VLAN configuration as 'public' network"
     end
   end
 

--- a/releases/development/openstack-build/network-openstack-10g-team.json
+++ b/releases/development/openstack-build/network-openstack-10g-team.json
@@ -278,42 +278,6 @@
             }
           }
         },
-        "nova_fixed": {
-          "conduit": "intf1",
-          "vlan": 500,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.123.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.123.255",
-          "router": "192.168.123.1",
-          "router_pref": 20,
-          "ranges": {
-            "router": {
-              "start": "192.168.123.1",
-              "end": "192.168.123.49"
-            },
-            "dhcp": {
-              "start": "192.168.123.50",
-              "end": "192.168.123.254"
-            }
-          }
-        },
-        "nova_floating": {
-          "conduit": "intf1",
-          "vlan": 300,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.126.128",
-          "netmask": "255.255.255.192",
-          "broadcast": "192.168.126.191",
-          "ranges": {
-            "host": {
-              "start": "192.168.126.129",
-              "end": "192.168.126.191"
-            }
-          }
-        },
         "bmc": {
           "conduit": "bmc",
           "vlan": 100,

--- a/releases/development/openstack-build/network-openstack-team.json
+++ b/releases/development/openstack-build/network-openstack-team.json
@@ -278,42 +278,6 @@
             }
           }
         },
-        "nova_fixed": {
-          "conduit": "intf1",
-          "vlan": 500,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.123.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.123.255",
-          "router": "192.168.123.1",
-          "router_pref": 20,
-          "ranges": {
-            "router": {
-              "start": "192.168.123.1",
-              "end": "192.168.123.49"
-            },
-            "dhcp": {
-              "start": "192.168.123.50",
-              "end": "192.168.123.254"
-            }
-          }
-        },
-        "nova_floating": {
-          "conduit": "intf1",
-          "vlan": 300,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.122.128",
-          "netmask": "255.255.255.192",
-          "broadcast": "192.168.122.191",
-          "ranges": {
-            "host": {
-              "start": "192.168.122.129",
-              "end": "192.168.122.191"
-            }
-          }
-        },
         "bmc": {
           "conduit": "bmc",
           "vlan": 100,

--- a/releases/development/openstack-os-build/network-openstack-10g-team.json
+++ b/releases/development/openstack-os-build/network-openstack-10g-team.json
@@ -278,42 +278,6 @@
             }
           }
         },
-        "nova_fixed": {
-          "conduit": "intf1",
-          "vlan": 500,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.123.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.123.255",
-          "router": "192.168.123.1",
-          "router_pref": 20,
-          "ranges": {
-            "router": {
-              "start": "192.168.123.1",
-              "end": "192.168.123.49"
-            },
-            "dhcp": {
-              "start": "192.168.123.50",
-              "end": "192.168.123.254"
-            }
-          }
-        },
-        "nova_floating": {
-          "conduit": "intf1",
-          "vlan": 300,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.126.128",
-          "netmask": "255.255.255.192",
-          "broadcast": "192.168.126.191",
-          "ranges": {
-            "host": {
-              "start": "192.168.126.129",
-              "end": "192.168.126.191"
-            }
-          }
-        },
         "bmc": {
           "conduit": "bmc",
           "vlan": 100,

--- a/releases/development/openstack-os-build/network-openstack-team.json
+++ b/releases/development/openstack-os-build/network-openstack-team.json
@@ -278,42 +278,6 @@
             }
           }
         },
-        "nova_fixed": {
-          "conduit": "intf1",
-          "vlan": 500,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.123.0",
-          "netmask": "255.255.255.0",
-          "broadcast": "192.168.123.255",
-          "router": "192.168.123.1",
-          "router_pref": 20,
-          "ranges": {
-            "router": {
-              "start": "192.168.123.1",
-              "end": "192.168.123.49"
-            },
-            "dhcp": {
-              "start": "192.168.123.50",
-              "end": "192.168.123.254"
-            }
-          }
-        },
-        "nova_floating": {
-          "conduit": "intf1",
-          "vlan": 300,
-          "use_vlan": true,
-          "add_bridge": false,
-          "subnet": "192.168.122.128",
-          "netmask": "255.255.255.192",
-          "broadcast": "192.168.122.191",
-          "ranges": {
-            "host": {
-              "start": "192.168.122.129",
-              "end": "192.168.122.191"
-            }
-          }
-        },
         "bmc": {
           "conduit": "bmc",
           "vlan": 100,


### PR DESCRIPTION
This is initial pull request for moving OpenStack Nova networks to barclamp-neutron.
This change will:
- simplify network configuration 
- gives better flexibility for user deployments.

Warning!!! Please don't merge this until it will be tested
