### PR TITLE
Move repos in /srv/tftpboot/suse-{11.3,12.0}/repos and create symlinks from SMT automatically

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -417,7 +417,7 @@ fi
 /usr/bin/lscpu  || :
 /bin/df -h  || :
 /usr/bin/free -m || :
-/bin/ls -la /srv/tftpboot/suse-{11.3,12.0}/{repos/,repos/Cloud/,install/} || :
+/bin/ls -la /srv/tftpboot/suse-{11.3,12.0}/{repos/,repos/Cloud/,repos/SLE12-Cloud-Compute/,install/} || :
 
 if [ -f /opt/dell/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb ]; then
     # The autoyast profile might not exist yet when CROWBAR_FROM_GIT is enabled

--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -579,6 +579,42 @@ check_media_links $MEDIA
 
 [ -e /srv/tftpboot/suse-12.0/install ] && check_media_links /srv/tftpboot/suse-12.0/install
 
+# Automatically create symlinks for SMT-mirrored repos if they exist
+for repo in SLES11-SP3-Pool \
+            SLES11-SP3-Updates \
+            SUSE-Cloud-5-Pool \
+            SUSE-Cloud-5-Updates \
+            SLE11-HAE-SP3-Pool \
+            SLE11-HAE-SP3-Updates; do
+  cloud_dir=/srv/tftpboot/suse-11.3/repos/$repo
+  smt_dir=/srv/www/htdocs/repo/\$RCE/$repo/sle-11-x86_64
+  test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+done
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SLES12-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/SLE-SERVER/12/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SLES12-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/SLE-SERVER/12/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SLE-12-Cloud-Compute5-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/12-Cloud-Compute/5/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SLE-12-Cloud-Compute5-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/12-Cloud-Compute/5/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SUSE-Enterprise-Storage-1.0-Pool
+smt_dir=/srv/www/htdocs/repo/SUSE/Products/Storage/1.0/x86_64/product
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
+cloud_dir=/srv/tftpboot/suse-12.0/repos/SUSE-Enterprise-Storage-1.0-Updates
+smt_dir=/srv/www/htdocs/repo/SUSE/Updates/Storage/1.0/x86_64/update
+test ! -e $cloud_dir -a -d $smt_dir && ln -s $smt_dir $cloud_dir
+
 #TODO check_repo_content SLE12-Cloud-Compute once we have official repo
 
 check_repo_content \


### PR DESCRIPTION
This does two things:
- move the repos to subdir: this makes more sense and clarifies for which distro is which repo
- reduces some setup complexity by creating the symlinks from SMT automatically

Note that this second bit is not complete yet as it depends on knowing some path from SMT...