### PR TITLE
Check for barclamp (crowbar) versions before install

### DIFF
--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -109,14 +109,24 @@ candidates.each do |bc|
     puts "Barclamp at #{bc} has no name, skipping"
     next
   end
+  version = barclamp["barclamp"]["version"].to_i rescue 0
   order = 9999
   if barclamp["crowbar"] and barclamp["crowbar"]["order"] and \
     barclamp["crowbar"]["order"].to_i 
     order = barclamp["crowbar"]["order"].to_i
   end
-  barclamps[name] = { :src => bc, :name => name, :order => order, :yaml => barclamp }
+  barclamps[name] = { :src => bc, :name => name, :order => order, :yaml => barclamp, :version => version }
   debug "barclamp[#{name}] = #{barclamps[name].pretty_inspect}"
 end
+
+debug "checking barclamp versions:"
+barclamps.values.sort_by{|v| v[:order]}.each do |bc|
+  if bc[:yaml]["nav"] && bc[:version] < 1
+    warn "Refusing to install #{bc[:name]} barclamp version < 1 due to incompatible navigation."
+    exit -1
+  end
+end
+debug "done"
 
 debug "installing barclamps:"
 barclamps.values.sort_by{|v| v[:order]}.each do |bc|

--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -109,12 +109,11 @@ candidates.each do |bc|
     puts "Barclamp at #{bc} has no name, skipping"
     next
   end
-  version = barclamp["barclamp"]["version"].to_i rescue 0
-  order = 9999
-  if barclamp["crowbar"] and barclamp["crowbar"]["order"] and \
-    barclamp["crowbar"]["order"].to_i 
-    order = barclamp["crowbar"]["order"].to_i
-  end
+
+  # We assume the barclamp and crowbar keys exist and their values are hashes.
+  version = (barclamp["barclamp"]["version"] || 0).to_i
+  order   = (barclamp["crowbar"]["order"] || 9999).to_i
+
   barclamps[name] = { :src => bc, :name => name, :order => order, :yaml => barclamp, :version => version }
   debug "barclamp[#{name}] = #{barclamps[name].pretty_inspect}"
 end

--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -121,7 +121,7 @@ end
 debug "checking barclamp versions:"
 barclamps.values.sort_by{|v| v[:order]}.each do |bc|
   if bc[:yaml]["nav"] && bc[:version] < 1
-    fatal("Refusing to install #{bc[:name]} barclamp version < 1 due to incompatible navigation.", "logs")
+    fatal("Refusing to install #{bc[:name]} barclamp version < 1 due to incompatible navigation.", nil, -1)
   end
 end
 debug "done"

--- a/releases/development/master/extra/barclamp_install.rb
+++ b/releases/development/master/extra/barclamp_install.rb
@@ -122,8 +122,7 @@ end
 debug "checking barclamp versions:"
 barclamps.values.sort_by{|v| v[:order]}.each do |bc|
   if bc[:yaml]["nav"] && bc[:version] < 1
-    warn "Refusing to install #{bc[:name]} barclamp version < 1 due to incompatible navigation."
-    exit -1
+    fatal("Refusing to install #{bc[:name]} barclamp version < 1 due to incompatible navigation.", "logs")
   end
 end
 debug "done"

--- a/releases/development/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/development/master/extra/barclamp_mgmt_lib.rb
@@ -58,9 +58,13 @@ def debug(msg)
   puts "DEBUG: " + msg if ENV['DEBUG'] === "true"
 end
 
-def fatal(msg, log)
-  puts "ERROR: #{msg}  Aborting; examine #{log} for more info."
-  exit 1
+def fatal(msg, log = nil, exit_code = 1)
+  str  = "ERROR: #{msg}  Aborting; "
+  if log
+    str += "Examine #{log} for more info."
+  end
+  puts str
+  exit exit_code
 end
 
 # entry point for scripts


### PR DESCRIPTION
As crowbar now uses incompatible navigation configs, we prevent incompatible barclamps from installing.

The appropriate version bumps are in the following PRs:

https://github.com/crowbar/barclamp-openstack/pull/79
https://github.com/crowbar/barclamp-tempest/pull/131
https://github.com/crowbar/barclamp-swift/pull/277
https://github.com/crowbar/barclamp-crowbar/pull/1215
https://github.com/crowbar/barclamp-network/pull/310
https://github.com/crowbar/barclamp-cisco-ucs/pull/11