### PR TITLE
install-chef-suse: Really make SLE12 checks optional

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -575,7 +575,7 @@ check_repo_tag repo    11.3 SLE11-HAE-SP3-Updates  'updates://zypp-patches.suse.
 
 # Checks for SLE12 media (currently optional)
 MEDIA=/srv/tftpboot/suse-12.0/install
-if [ -e $MEDIA ]; then
+if [ -e $MEDIA/install/boot/x86_64/common ]; then
   check_media_content \
       SLES12 \
       $MEDIA \


### PR DESCRIPTION
/srv/tftpboot/suse-12.0/install is installed by the crowbar package, so
trying to skip the SLE12 checks if that directory is missing doesn't
make sense.

Instead, use the same check we have in barclamp-provisioner
(/srv/tftpboot/suse-12.0/install/boot/x86_64/common).