### PR TITLE
fix installation to work with -DEPS .iso

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -549,7 +549,7 @@ MEDIA=/srv/tftpboot/suse-11.3/install
 
 if [ -f $MEDIA/content ] && egrep -q "REPOID.*/suse-cloud-deps/" $MEDIA/content; then
     echo "Detected SUSE Cloud Deps media."
-    REPOS_SKIP_CHECKS+=" SLES11-SP3-Pool"
+    REPOS_SKIP_CHECKS+=" SLES11-SP3-Pool SLES11-SP3-Updates"
 else
     check_media_content \
         SLES11_SP3 \


### PR DESCRIPTION
The SP3-Updates repo is not needed when the -DEPS .iso is present,
since -DEPS includes latest SP3 updates.