### PR TITLE
only require use of GNU screen over ssh

### DIFF
--- a/releases/development/master/extra/install-chef-suse.sh
+++ b/releases/development/master/extra/install-chef-suse.sh
@@ -281,7 +281,7 @@ fi
 
 echo_summary "Performing sanity checks"
 
-if test -z "$STY"; then
+if [ -n "$SSH_CONNECTION" -a -z "$STY" ]; then
     die "Not running in screen. Please use \"screen $0\" to avoid problems during network re-configuration. Aborting."
 fi
 


### PR DESCRIPTION
If we're logged in at the console, use of screen should be optional, since there's no risk of losing access when the network gets reconfigured.

Idea stolen from:

https://github.com/crowbar/barclamp-provisioner/pull/388/files#diff-945d060a9723ccccce160d5b86130cc6R95