### PR TITLE
Fix path for barclamp_install.rb

### DIFF
--- a/releases/stoney/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/stoney/master/extra/barclamp_mgmt_lib.rb
@@ -427,7 +427,7 @@ def bc_install_layout_1_chef(from_rpm, bc, bc_path, yaml)
   log = File.join log_path, "#{bc}.log"
   File.open(log, "a") { |f| f.puts("======== Installing #{bc} barclamp -- #{Time.now.strftime('%c')} ========") }
   debug "Capturing chef install logs to #{log}"
-  chef = File.join bc_path, 'chef'
+  chef = File.join '/opt/dell', 'chef'
   cookbooks = File.join chef, 'cookbooks'
   databags = File.join chef, 'data_bags'
   roles = File.join chef, 'roles'


### PR DESCRIPTION
When installing a barclamp not from rpm, but from a file location, a non-
correct path is used resulting in not installed roles etc. This fixes
the path

Note: This will upload all data bags and roles present in the path. Worth fixing this too?