### PR TITLE
Create assets folder while installing

### DIFF
--- a/releases/development/master/extra/barclamp_mgmt_lib.rb
+++ b/releases/development/master/extra/barclamp_mgmt_lib.rb
@@ -281,6 +281,11 @@ def generate_assets_manifest
     merged_json.deep_merge!(json) unless json.nil?
   end
 
+  assets_folder = File.join(CROWBAR_PATH, 'public', 'assets')
+  unless File.directory? assets_folder
+    FileUtils.mkdir_p assets_folder
+  end
+
   File.open(
     File.join(CROWBAR_PATH, 'public', 'assets', 'manifest.json'),
     'w'


### PR DESCRIPTION
Create the public asset folder to prevent error while installing the
barclamps for the first time. This case happens only when setting up the
development envoiremt or installing from git.