### PR TITLE
Add barclamps/.gitignore

### DIFF
--- a/barclamps/.gitignore
+++ b/barclamps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Create the barclamps folder and ignore everything inside this folder.
This change makes it easier for crowbar developers because they have cloned
all baclamps inside the barclamps folder.