### PR TITLE
Relax requirements for nova_floating and public

### DIFF
--- a/releases/development/master/extra/network-json-validator
+++ b/releases/development/master/extra/network-json-validator
@@ -184,6 +184,7 @@ class CrowbarNetwork
   attr_reader :broadcast_addr
   attr_reader :subnet_addr_full
   attr_reader :ranges
+  attr_reader :router
   attr_reader :conduit
   attr_reader :vlan
   attr_reader :use_vlan
@@ -417,18 +418,9 @@ def validate_networks databag
     end
   end
 
-  if not @networks['public'].subnet_addr_full.include?(@networks['nova_floating'].subnet_addr_full)
-    raise "'nova_floating' network must be a subnetwork of 'public' network"
-  end
-
-  if @networks['public'].use_vlan != @networks['nova_floating'].use_vlan
-    raise "The 'Use VLAN' setting (JSON attribute: 'use_vlan') of the 'nova_floating' and 'public' networks must be the same."
-  end
-
-  if @networks['public'].use_vlan
-    if @networks['public'].vlan != @networks['nova_floating'].vlan
-      raise "'nova_floating' network must have the same VLAN configuration as 'public' network"
-    end
+  if !@networks['public'].subnet_addr_full.include?(@networks['nova_floating'].subnet_addr_full) &&
+    @networks['nova_floating'].router.nil?
+    raise "'nova_floating' network must have a router defined when not a subnetwork of 'public' network"
   end
 
   if @networks['bmc'].subnet_addr_full != @networks['admin'].subnet_addr_full


### PR DESCRIPTION
Technically there is not requirement for nova_floating and public to be on the
same VLAN and for nova_floating to be a subnet of public. This commit reworks
the requirements of the network validator so that allow floating and public to be
on different networks.

(cherry picked from commit 52b491fe646e29926c6b7c6468e59b5464a6971c)