### PR TITLE
Set `sudo: false` to run travis tests in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: bash
-sudo: true
+sudo: false
 install:
     - make install
 script:


### PR DESCRIPTION
This change should shorten the time until the travis test start.