### PR TITLE
Set `sudo: false` to run travis tests in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: bash
-sudo: true
+language: python
+sudo: false
 install:
-    - make install
+  - "pip install bashate"
 script:
-    - make test
+  - make test


### PR DESCRIPTION
This change should shorten the time until the travis test starts.

See http://docs.travis-ci.com/user/migrating-from-legacy/"