### PR TITLE
install-chef-suse: Stop some services before reinstalling (bsc#928183)

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -749,7 +749,7 @@ chef-client
 echo_summary "Installing barclamps"
 
 # Clean up previous crowbar install run, in case there was one
-service crowbar status > /dev/null && service crowbar stop
+service crowbar status &> /dev/null && service crowbar stop
 for i in $BARCLAMP_SRC/*; do
     if test -d $i -a -f $i-filelist.txt; then
         /opt/dell/bin/barclamp_uninstall.rb $BARCLAMP_INSTALL_OPTS $i

--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -710,6 +710,9 @@ done
 
 echo_summary "Performing initial chef-client run"
 
+# Stop chef-client daemon to avoid interferences
+service chef-client status &> /dev/null && service chef-client stop
+
 if ! [ -e ~/.chef/knife.rb ]; then
     yes '' | knife configure -i
 fi


### PR DESCRIPTION
This is needed so that we're sure they'll be started with the right
config (and won't fail to restart in a notification due to some chef
crash).

The services in question are apache2, dhcpd, nfsserver, xinetd.

In theory, we should also stop dnsmasq, named and ntpd, but we don't
want to lose DNS and ntpd might be queried for its configuration later
on.

https://bugzilla.suse.com/show_bug.cgi?id=928183