### PR TITLE
Require 'ses' component for storage-only installs

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -81,7 +81,7 @@ mkdir -p "`dirname "$LOGFILE"`"
 run_succeeded=
 
 is_ses () {
-    [ -d /opt/dell/barclamps/suse-enterprise-storage ]
+    [ -d /opt/dell/barclamps/ses ]
 }
 
 
@@ -813,7 +813,7 @@ fi
 
 required_components="core"
 if is_ses ; then
-    required_components+=" suse-enterprise-storage ceph"
+    required_components+=" ses ceph"
 else
     required_components+=" openstack ha ceph"
 fi


### PR DESCRIPTION
Prior to the big crowbar repo merge, the SUSE Enterprise Storage package
was named 'crowbar-barclamp-suse-enterprise-storage'.  Now it's got a
nice short component name ('crowbar-ses'), so need to update the install
script to match.

Signed-off-by: Tim Serong <tserong@suse.com>