### PR TITLE
install-chef-suse: Re-run knife if /root/.chef/root.pem is missing

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -753,7 +753,7 @@ echo_summary "Performing initial chef-client run"
 # Stop chef-client daemon to avoid interferences
 service chef-client status &> /dev/null && service chef-client stop
 
-if ! [ -e ~/.chef/knife.rb ]; then
+if ! [ -e ~/.chef/knife.rb -a -e ~/.chef/root.pem ]; then
     yes '' | knife configure -i
 fi
 


### PR DESCRIPTION
On re-run of install-chef-suse.sh, if we have /root/.chef/knife.rb but
not /root/.chef/root.pem, then we assume that knife is working while it
actually needs the certificate. So also check for existence of
/root/.chef/root.pem.