### PR TITLE
Revert "Append always .title to navi i18n keys"

### DIFF
--- a/scripts/barclamp_mgmt_lib.rb
+++ b/scripts/barclamp_mgmt_lib.rb
@@ -179,7 +179,7 @@ def prepare_navigation(hash, breadcrumb, indent, level)
       options_string.prepend(", ") unless options_string.empty?
 
       if values.keys.empty?
-        result.push "level#{level}.item :#{key}, t(\"nav.#{current_path.join(".")}.title\"), #{link}#{options_string}".indent(indent)
+        result.push "level#{level}.item :#{key}, t(\"nav.#{current_path.join(".")}\"), #{link}#{options_string}".indent(indent)
       else
         result.push "level#{level}.item :#{key}, t(\"nav.#{current_path.join(".")}.title\"), #{link}#{options_string} do |level#{level + 1}|".indent(indent)
         result.push prepare_navigation(values, current_path, indent + 2, level + 1)


### PR DESCRIPTION
This reverts commit 194bc8d804ebf6af181d65b654d1de1527fbee62.

This part is broken afterwards:
```yml
  nav:
    nodes:
      title: 'Nodes'
      dashboard: 'Dashboard'
      batch: 'Bulk Edit'
      clusters: 'HA Clusters'
      roles: 'Active Roles'
      families: 'Family Groups'
    barclamps:
      title: 'Barclamps'
      all: 'All Barclamps'
      crowbar: 'Crowbar'
      queue: 'Deployment Queue'
    utils:
      title: 'Utilities'
      logs: 'Exported Items'
      repositories: 'Repositories'
    help:
      title: 'Help'
      docs: 'Documentation'
      crowbar_users: 'Crowbar Users Guide'
      wiki: 'Online Help'
```

fix would be to add the title everywhere like:

```yml
  nav:
    nodes:
      title: 'Nodes'
      dashboard:
        title: 'Dashboard'
```

but this seams not a good solution form me.

Revert is already in the package and branding patch is adapted.