### PR TITLE
Sync codeclimate config, remove bundler-audit

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,8 +8,6 @@ engines:
     enabled: true
   scss-lint:
     enabled: true
-  bundler-audit:
-    enabled: true
 
 ratings:
   paths:
@@ -21,5 +19,3 @@ ratings:
 exclude_paths:
   - spec/**/*
   - vendor/**/*
-
-  - .artifacts


### PR DESCRIPTION
Remove bundler-audit check, it won't work as we are not providing any Gemfile.lock within git.