### PR TITLE
Revert "always cleanup the rails db"

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -278,15 +278,6 @@ post_fail_handler ()
     rm -f $crowbar_install_dir/crowbar_installing
 }
 
-function reset_crowbar()
-{
-    rm -f $crowbar_install_dir/crowbar-install-failed
-    rm -f $installation_steps
-    pushd /opt/dell/crowbar_framework > /dev/null
-    bin/rake db:cleanup
-    popd > /dev/null
-}
-
 # Real work starts here
 # ---------------------
 
@@ -318,7 +309,11 @@ EOF
     exit 1
 fi
 
-reset_crowbar
+if [ -f $crowbar_install_dir/crowbar-install-failed ] || [ "$CROWBAR_WIZARD_MODE" ]; then
+    rm -f $crowbar_install_dir/crowbar-install-failed
+    rm -f $installation_steps
+    sqlite3 /opt/dell/crowbar_framework/db/production.sqlite3 "delete from proposals; delete from proposal_queues; vacuum;"
+fi
 
 FQDN=$(hostname -f 2>/dev/null);
 DOMAIN=$(hostname -d 2>/dev/null);


### PR DESCRIPTION
This breaks with 

== 20150806114015 CreateProposalQueues: reverting =============================
-- drop_table(:proposal_queues)
rake aborted!
SQLite3::SQLException: no such table: proposal_queues: DROP TABLE "proposal_queues"
/opt/dell/crowbar_framework/lib/tasks/database.rake:28:in `block (4 levels) in <top (required)>'
/opt/dell/crowbar_framework/lib/tasks/database.rake:26:in `each'
/opt/dell/crowbar_framework/lib/tasks/database.rake:26:in `block (3 levels) in <top (required)>'
/opt/dell/crowbar_framework/lib/tasks/database.rake:22:in `tap'
/opt/dell/crowbar_framework/lib/tasks/database.rake:22:in `block (2 levels) in <top (required)>'
Tasks: TOP => db:cleanup
(See full trace by running task with --trace)


Reverts crowbar/crowbar#2189