### PR TITLE
use ntpq to detect live ntp servers (boo#958721)

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -894,7 +894,7 @@ if [ -z "$custom_ntp_servers" ]; then
     ntp_servers="$( awk '/^server / && ! / 127\./ { print $2 }' < /etc/ntp.conf )"
     if [ -z "$ntp_servers" ]; then
         echo "Auto-detecting existing ntp servers from ntpd ..."
-        ntp_servers="$( ntpdc -l | awk '/client/ && ! /LOCAL/ { print $2 }' )"
+        ntp_servers="$( ntpq -wp | tail -n +3 | cut -c2- | grep '^[^ ]' | awk '! /LOCL/ { print $1 }' )"
     fi
     if [ -n "$ntp_servers" ]; then
         ntp_servers="${ntp_servers%$'\n'}" # trim trailing newline


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=958721#c2
explains that ntpdc is now disabled
so we cannot use it anymore for detecting ntp servers from ntpd
