### PR TITLE
install-chef-suse: Do not call rake as root

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -282,9 +282,7 @@ function reset_crowbar()
 {
     rm -f $crowbar_install_dir/crowbar-install-failed
     rm -f $installation_steps
-    pushd /opt/dell/crowbar_framework > /dev/null
-    RAILS_ENV=production bin/rake db:cleanup
-    popd > /dev/null
+    su -s /bin/sh - crowbar sh -c "cd /opt/dell/crowbar_framework && RAILS_ENV=production bin/rake db:cleanup"
 }
 
 # Real work starts here


### PR DESCRIPTION
When we do this, it creates /var/log/crowbar/production.log owned by
root, which makes the rails app unstartable later on because it can't
write to the log.