### PR TITLE
install-chef-suse: Skip detection of ntp servers when no ntp.conf exists

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -897,7 +897,7 @@ else
 fi
 
 custom_ntp_servers="$( json_read "$NTP_JSON" attributes.ntp.external_servers )"
-if [ -z "$custom_ntp_servers" ]; then
+if [ -z "$custom_ntp_servers" -a -f /etc/ntp.conf ]; then
     # Use existing ntp servers, if any.  We prefer servers in
     # /etc/ntp.conf over servers currently used by a running ntpd,
     # since (a) configuring ntp.conf is a more deliberate manual


### PR DESCRIPTION
Right now, we are failing because we try to parse ntp.conf. We know
there's no ntp running anyway if there's no file, so we can skip the
detection completely.