### PR TITLE
install-chef-suse: Fix usage of DEPS iso

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -509,22 +509,22 @@ for arch in $product_arches; do
         continue
     fi
 
-    if [ -f $MEDIA/content ] && egrep -q "REPOID.*/suse-cloud-deps/" $MEDIA/content; then
+    check_media_links $MEDIA
+
+    if [ -f $MEDIA/content ] && egrep -q "REPOID.*/suse-openstack-cloud-deps/" $MEDIA/content; then
         echo "Detected SUSE OpenStack Cloud Deps media."
     else
         check_media_content \
             SLES12-SP1 \
             $MEDIA \
             #b52c0f2b41a6a10d49cc89edcdc1b13d
-    fi
 
-    check_media_links $MEDIA
-
-    if ! is_ses; then
-        check_media_content \
-            Cloud \
-            /srv/tftpboot/suse-12.1/$arch/repos/Cloud \
-            #1558be86e7354d31e71e7c8c2574031a
+        if ! is_ses; then
+            check_media_content \
+                Cloud \
+                /srv/tftpboot/suse-12.1/$arch/repos/Cloud \
+                #1558be86e7354d31e71e7c8c2574031a
+        fi
     fi
 done
 


### PR DESCRIPTION
The test was wrong, and the Cloud repo is gone now (integrated in the
DEPS iso).