### PR TITLE
install-chef-suse: Run barclamp_install.rb only once

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -767,13 +767,12 @@ if is_ses ; then
 else
     required_components+=" openstack ha ceph"
 fi
-
-/opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS $required_components
-
 # Install optional components if they're present
 if test -d $BARCLAMP_SRC/hyperv; then
-    /opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS hyperv
+    required_components+=" hyperv"
 fi
+
+/opt/dell/bin/barclamp_install.rb $BARCLAMP_INSTALL_OPTS $required_components
 
 set_step "barclamp_install"
 


### PR DESCRIPTION
We were calling it a second time just for hyperv. Instead, call it with
hyperv the first time. This saves some time in the install process.