### PR TITLE
Adjust to updated Devel:Cloud Key

### DIFF
--- a/scripts/repos-check-suse
+++ b/scripts/repos-check-suse
@@ -48,7 +48,7 @@ check_key_file () {
     9a62177e1c6852d48453ed3909956d6b)
       # SLE12 key
       ;;
-    6e2920076653964b7de9d6d0421955bb)
+    d91f7a13ddadd614001c965f6abb1613)
       # Devel:Cloud key
       ;;
     *)


### PR DESCRIPTION
The Key lifetime was extended today, adjust to the new md5

(cherry picked from commit 25f6b961d4475ff877be97a45133d2900c01935a)