### PR TITLE
Fix last change to work in all locales

### DIFF
--- a/releases/development/master/extra/repos-check-suse
+++ b/releases/development/master/extra/repos-check-suse
@@ -42,7 +42,7 @@ check_key_file () {
   key_file=$1
 
   local fingerprint
-  read -a fingerprint < <(gpg --with-fingerprint ${key_file} \
+  read -a fingerprint < <(LC_ALL=C gpg --with-fingerprint ${key_file} \
       | grep fingerprint | awk -F= '{print $2}')
   case "${fingerprint[@]}" in
     "4E98 E675 19D9 8DC7 362A 5990 E3A5 C360 307E 3D54") # SLE11 keys


### PR DESCRIPTION
the grep for "fingerprint" only works in C locale, not if you
use a different locale.

(cherry picked from commit daaa69b76065999337cd1344fd0efb2ff56f77d7)