### PR TITLE
define $DNS_JSON in the same way as $PROVISIONER_JSON

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -391,11 +391,14 @@ json_read () {
     fi | sed "s/^[^=]*=//g"
 }
 
-if [ -f /etc/crowbar/provisioner.json ]; then
-    PROVISIONER_JSON=/etc/crowbar/provisioner.json
-elif [ -n "$CROWBAR_FROM_GIT" -a -f /root/crowbar/provisioner.json ]; then
-    PROVISIONER_JSON=/root/crowbar/provisioner.json
-fi
+for bc in provisioner dns; do
+    if [ -f /etc/crowbar/$bc.json ]; then
+        # ${bc^^} simply uppercases $bc
+        eval "${bc^^}_JSON=/etc/crowbar/$bc.json"
+    elif [ -n "$CROWBAR_FROM_GIT" -a -f /root/crowbar/$bc.json ]; then
+        eval "${bc^^}_JSON=/root/crowbar/$bc.json"
+    fi
+done
 
 if [ -n "$IPv4_addr" ]; then
     if [ -f /etc/crowbar/network.json ]; then


### PR DESCRIPTION
23794e55b started referring to DNS_JSON without ever defining it, so apparently this ability to override DNS settings during install via `/{etc,root}/crowbar/dns.json` has been broken for 3 years and 3 days ...

Another example of why #shellsucks - undefined variables are silently used without any error or even warning.
