### PR TITLE
Refactor running rake (bsc#993035)

### DIFF
--- a/scripts/barclamp_install.rb
+++ b/scripts/barclamp_install.rb
@@ -133,16 +133,8 @@ end
 barclamps.sort!
 
 if do_chef
-  bc_install_layout_1_chef
-
-  begin
-    bc_install_schema_migrate barclamps, log
-  rescue StandardError => e
-    puts e
-    puts e.backtrace
-    puts "Migration of barclamps #{barclamps.join(", ")} failed."
-    exit_code = -3
-  end
+  bc_install_layout_1_chef log
+  bc_install_schema_migrate barclamps, log
 end
 
 generate_navigation

--- a/scripts/barclamp_mgmt_lib.rb
+++ b/scripts/barclamp_mgmt_lib.rb
@@ -26,6 +26,7 @@ require "active_support/all"
 require "pp"
 require "i18n"
 require "pathname"
+require "etc"
 
 if I18n.respond_to? :enforce_available_locales
   I18n.enforce_available_locales = false
@@ -415,24 +416,36 @@ def bc_install_layout_1_app(from_rpm, bc_path)
   debug "Component #{component} added to Crowbar Framework.  Review #{filelist} for files created."
 end
 
-# sync the chef parts
-def bc_install_layout_1_chef
+def run_rake_task(task_name, log)
+  crowbar_user = Etc.getpwnam("crowbar")
   rails_env = ENV["RAILS_ENV"] || "production"
-  upload_cmd = "cd #{CROWBAR_PATH} && RAILS_ENV=#{rails_env} bin/rake chef:upload:all"
-  system "su -s /bin/sh - crowbar sh -c \"#{upload_cmd}\""
+  debug("spawning bin/rake #{task_name}")
+  rake_process = spawn({ "RAILS_ENV" => rails_env },
+                       "bin/rake --silent #{task_name}",
+                       :uid => crowbar_user.uid,
+                       :gid => crowbar_user.gid,
+                       :chdir => CROWBAR_PATH,
+                       [:out, :err] => [log, "a"])
+  Process.wait rake_process
+  status = $?
+  debug("bin/rake exited with #{status.exitstatus}")
+  status.success?
+end
+
+# sync the chef parts
+def bc_install_layout_1_chef(log)
+  unless run_rake_task("chef:upload:all", log)
+    fatal "Failed to upload cookbooks to chef.", log
+  end
 end
 
 def bc_install_schema_migrate(barclamps, log)
   debug "Migrating barclamps #{barclamps.join(", ")} to new schema revision..."
   File.open(log, "a") { |f| f.puts("======== Migrating #{barclamps.join(", ")} barclamps -- #{Time.now.strftime('%c')} ========") }
-  migrate_cmd = "cd #{CROWBAR_PATH} && RAILS_ENV=#{ENV["RAILS_ENV"] || "production"} bin/rake --silent crowbar:schema_migrate[#{barclamps.join(",")}] 2>&1"
-  migrate_cmd_su = "su -s /bin/sh - crowbar sh -c \"#{migrate_cmd}\" >> #{log}"
-  debug "running #{migrate_cmd_su}"
-  unless system migrate_cmd_su
+  unless run_rake_task("crowbar:schema_migrate[#{barclamps.join(",")}]", log)
     fatal "Failed to migrate barclamps #{barclamps.join(", ")} to new schema revision.", log
   end
-  debug "\t executed: #{migrate_cmd_su}"
-  puts "Barclamps #{barclamps.join(", ")} Migrated to New Schema Revision."
+  puts "Barclamps #{barclamps.join(", ")} migrated to New Schema Revision."
 end
 
 def get_rpm_file_list(rpm)

--- a/scripts/barclamp_mgmt_lib.rb
+++ b/scripts/barclamp_mgmt_lib.rb
@@ -16,16 +16,16 @@
 # limitations under the License.
 #
 
-require 'rubygems'
-require 'fileutils'
-require 'yaml'
-require 'json'
-require 'time'
-require 'tempfile'
-require 'active_support/all'
-require 'pp'
-require 'i18n'
-require 'pathname'
+require "rubygems"
+require "fileutils"
+require "yaml"
+require "json"
+require "time"
+require "tempfile"
+require "active_support/all"
+require "pp"
+require "i18n"
+require "pathname"
 
 if I18n.respond_to? :enforce_available_locales
   I18n.enforce_available_locales = false


### PR DESCRIPTION
If barclamp_install fails to upload cookbooks, it does not check the
exit status of the bin/rake call, and merrily continues on, finally
exiting with status 0. Refactor the code that calls bin/rake to
no longer make use of system() or su, and instead use spawn(). This
also means that output from bin/rake chef:upload:all is also logged,
it wasn't previously.

Also clean-up the begin/rescue block when running schema migrations,
the function exits if there is an error, and doesn't throw an
exception.