### PR TITLE
Fix rubocop ruby version

### DIFF
--- a/.hound.ruby.yml
+++ b/.hound.ruby.yml
@@ -1,6 +1,7 @@
 inherit_from: .hound.suse.yml
 
 AllCops:
+  TargetRubyVersion: 2.1
   Rails:
     Enabled: true
   DisplayStyleGuide: true


### PR DESCRIPTION
Rubocop should test against the ruby version we use otherwise it can
happen that it shows wrong messages.

For example https://github.com/crowbar/crowbar-openstack/pull/516#discussion_r77812739 which is a ruby 2.3 feature. 