### PR TITLE
Set no_proxy in install-chef-suse.sh (bsc#998968)

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -342,6 +342,9 @@ reset_crowbar
 FQDN=$(hostname -f 2>/dev/null);
 DOMAIN=$(hostname -d 2>/dev/null);
 IPv4_addr=$( getent ahosts $FQDN 2>/dev/null | awk '{ if ($1 !~ /:/) { print $1; exit } }' )
+# Set no_proxy for localhost, the FQDN and the hostname, so chef will not use
+# the proxy for them.
+export no_proxy="$no_proxy,localhost,$FQDN,$IPv4_addr"
 
 # Sanity checks
 # -------------
@@ -668,9 +671,6 @@ echo_summary "Performing initial chef-client run"
 service chef-client status &> /dev/null && service chef-client stop
 
 if ! [ -e ~/.chef/knife.rb -a -e ~/.chef/root.pem ]; then
-    # no_proxy is currently not supported in ruby see bsc#958716
-    # unset it for this call
-    (unset http_proxy
     if knife client list | grep -q "^ *root$"; then
         knife client delete --yes root
     fi
@@ -684,7 +684,6 @@ if ! [ -e ~/.chef/knife.rb -a -e ~/.chef/root.pem ]; then
     --validation-client-name chef-validator \
     --validation-key /etc/chef/validation.pem \
     --repository ""
-    )
 fi
 
 # Reset chef to install from clean state


### PR DESCRIPTION
Chef now works around a missing Ruby feature by checking no_proxy
itself and matching against it when returning if a proxy connection
is required, so drop the http_proxy workaround and set no_proxy
directly. Since the script talks to both the hostname and the IP, add
them both.

Cherry-picked from 43d7b604bd7e8753dfbd5b31fb838b0087ea4adf.