### PR TITLE
[3.0] Do not require deprecated /etc/sysconfig/clock (bsc#983837)

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -880,7 +880,7 @@ fi
 
 # Use current time zone
 (
-    . /etc/sysconfig/clock
+    . /etc/sysconfig/clock || : Ignoring missing /etc/sysconfig/clock
     if [ -n "$TIMEZONE" ]; then
         echo "Will use $TIMEZONE timezone for node installation"
         $json_edit "$PROVISIONER_JSON" \


### PR DESCRIPTION
As a stop gap before this code is rewritten to use the systemd
methods, just ignore the failure since the whole feature is optional
anyway.

(cherry picked from commit e093088398192ce0a0bc25e105b3db3636daa9aa)