### PR TITLE
install-chef-suse: Stop creating PTF repo for SLES 12 SP1

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -562,12 +562,10 @@ fi
 
 
 for arch in $supported_arches; do
-    # We will need support for SP1 (ceph) and SP2 nodes
-    check_or_create_ptf_repository 12.1 $arch PTF
+    # We will need support for SP2 nodes
     check_or_create_ptf_repository 12.2 $arch PTF
 
     # Currently we only sign the PTF repository
-    sign_repositories 12.1 $arch PTF
     sign_repositories 12.2 $arch PTF
 done
 


### PR DESCRIPTION
We moved to SES 4, so no usage of SP1 is left.