### PR TITLE
upgrade: make a backup of the important database state (bsc#1012177)

### DIFF
--- a/scripts/upgrade_admin_server.sh
+++ b/scripts/upgrade_admin_server.sh
@@ -56,7 +56,9 @@ upgrade_admin_server()
     # we will need the dump for later migrating it into postgresql
     pushd /opt/dell/crowbar_framework
     sudo -u crowbar RAILS_ENV=production bin/rake db:migrate
+    cp -a db/schema.rb /var/lib/crowbar/upgrade
     sudo -u crowbar RAILS_ENV=production bin/rake db:dump
+    cp -a db/data.yml /var/lib/crowbar/upgrade
     popd
 
     ### Chef-client could lockj zypper and break upgrade


### PR DESCRIPTION
in some occasions the files have disappeared for unknown reasons after
the admin server upgrade.
not only because of that it makes sense to copy them away to a safe
place.

(cherry picked from commit 884944c900f5de1d3ce089bdea6c859fbcc2854e)