### PR TITLE
sledgehammer: Start rpcbind before using showmount

### DIFF
--- a/sledgehammer/start-up.sh
+++ b/sledgehammer/start-up.sh
@@ -149,6 +149,9 @@ echo "# Sledgehammer added to log to the admin node" >> /etc/rsyslog.conf
 echo "*.* @@${ADMIN_IP}" >> /etc/rsyslog.conf
 service $RSYSLOGSERVICE restart
 
+# showmount needs a running rpcbind service
+service rpcbind start
+
 # Setup common dirs based on what the Crowbar admin server is sharing
 exports=$(showmount -e $ADMIN_IP --no-headers | cut -f1 -d " ")
 for d in $exports; do


### PR DESCRIPTION
When calling "showmount" in start-up.sh when no rpcbind service
is running, the error is:

clnt_create: RPC: Port mapper failure - Unable to receive: errno 111
             (Connection refused)

Which leads to an empty "exports" variable and some follow-up errors.