### PR TITLE
crowbar-backup-cronjob: recommend .crowbarrc

### DIFF
--- a/scripts/crowbar-backup-cronjob
+++ b/scripts/crowbar-backup-cronjob
@@ -1,6 +1,8 @@
 #!/bin/sh
 # example backup script to be added in /etc/cron.daily/
 btarballname=crowbar-$(date +%F)
-p="--password=crowbar"
-crowbarctl backup create $btarballname $p && \
+# must have setup a ~/.crowbarrc containing
+#[default]
+#password = xxx
+crowbarctl backup create $btarballname && \
 echo "Created backup in /var/lib/crowbar/backup/$btarballname.tar.gz"


### PR DESCRIPTION
instead of hardcoded password