### PR TITLE
lgtm: Remove old .lgtm config

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,3 +1,0 @@
-approvals = 2
-pattern = "(?i):\\+1:|\\+1"
-self_approval_off = true


### PR DESCRIPTION
We stopped using lgtm since some time back, let's remove this config.