### PR TITLE
Wait longer for DHCP to kick in

### DIFF
--- a/sledgehammer/start-up.sh
+++ b/sledgehammer/start-up.sh
@@ -103,7 +103,7 @@ if ! suse_ver 12; then
 else
     if [ "$BOOTDEV" != "eth0" ]; then
         mv /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-$BOOTDEV
-        ifup $BOOTDEV
+        wicked ifup --timeout ${WAIT_FOR_INTERFACES:-60} $BOOTDEV
     fi
 fi
 


### PR DESCRIPTION
Apparently in some cases spanning tree blocks dhcp responses for
up to 50s, so wait 60s.