### PR TITLE
rubocop: Set max BlockLength to 40 and ignore spec files

### DIFF
--- a/.hound.ruby.yml
+++ b/.hound.ruby.yml
@@ -36,3 +36,8 @@ Metrics/ClassLength:
 
 Metrics/ModuleLength:
   Max: 500
+
+Metrics/BlockLength:
+  Max: 40
+  Exclude:
+    - "**/spec/**/*.rb"


### PR DESCRIPTION
The default block lenght is too short for crowbar and leads to many
false positives. Also by nature spec files have longer blocks so let's
ignore them.