### PR TITLE
Use crowbarctl to activate repositories

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -1166,7 +1166,7 @@ touch $crowbar_install_dir/crowbar-installed-ok
 rm -f $crowbar_install_dir/crowbar_installing
 
 # activate provisioner repos
-curl -X POST http://localhost:3000/utils/repositories/activate_all.json
+crowbarctl repository activate-all
 
 kill_spinner
 


### PR DESCRIPTION
In order to make dealing with an HTTPS crowbar server easier and just to
avoid ugly curl commands, replace the curl call in the install script
with the equivalent crowbarctl call.

https://trello.com/c/2SwQTBg1