### PR TITLE
install-chef-suse: Configure epmd.socket correctly

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -665,6 +665,16 @@ if [ ! -f /etc/rabbitmq/rabbitmq.config ] ; then
 EOF
 fi
 
+# Tell system-widde epmd to listen on right address (new rabbitmq-server
+# packages use this epmd service)
+mkdir -p /etc/systemd/system/epmd.socket.d
+cat << EOF > /etc/systemd/system/epmd.socket.d/port.conf
+[Socket]
+ListenStream=$IPv4_addr:4369
+FreeBind=true
+EOF
+systemctl daemon-reload
+
 chkconfig rabbitmq-server on
 ensure_service_running rabbitmq-server
 


### PR DESCRIPTION
With new erlang and rabbitmq-server packages, rabbitmq now depends on
the system-wide epmd service, which will only listen on IP addresses
defined for epmd.socket.

We need epmd to listen on the admin IP address (the one that resolves
the FQDN), so configure things accordingly.