### PR TITLE
[4.0] Use crowbarctl to activate repositories

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -1174,7 +1174,7 @@ touch $crowbar_install_dir/crowbar-installed-ok
 rm -f $crowbar_install_dir/crowbar_installing
 
 # activate provisioner repos
-curl -X POST http://localhost:3000/utils/repositories/activate_all.json
+crowbarctl repository activate-all
 
 kill_spinner
 


### PR DESCRIPTION
In order to make dealing with an HTTPS crowbar server easier and just to
avoid ugly curl commands, replace the curl call in the install script
with the equivalent crowbarctl call.

(cherry picked from commit ce5259ce585d89f18df82064873309ca14a7ebe0)

Backport of https://github.com/crowbar/crowbar/pull/2336