### PR TITLE
sledgehammer: wait for network (bsc#985556)

### DIFF
--- a/sledgehammer/start-up.sh
+++ b/sledgehammer/start-up.sh
@@ -150,8 +150,13 @@ echo "*.* @@${ADMIN_IP}" >> /etc/rsyslog.conf
 service $RSYSLOGSERVICE restart
 
 # Sometimes at this point network is not up yet, wait for it
-echo "Waiting for admin server ($ADMIN_IP) to be reachable; will wait up to 60 seconds..."
-ping -c 1 -w 60 $ADMIN_IP > /dev/null || {
+n=60
+echo "Waiting for admin server ($ADMIN_IP) to be reachable; will wait up to $n seconds..."
+while (( $n > 0 )) && ! ping -q -c 1 -w 1 $ADMIN_IP > /dev/null ; do
+    sleep 1
+    let n--
+done
+(( $n > 0 )) || {
     echo "Admin server ($ADMIN_IP) not reachable."
     echo "Things will end badly."
 }


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=985556

Sometimes our start-up.sh runs before wicked's dhcp client
brought the network up.
In that case the old ping would return immediately with
'connect: Network is unreachable'
so we need to sleep and retry for a while
because without NFS we cannot really do any node discovery.