### PR TITLE
[4.0] upgrade: fix epmd during upgrade

### DIFF
--- a/scripts/upgrade_admin_server.sh
+++ b/scripts/upgrade_admin_server.sh
@@ -113,6 +113,20 @@ n.save"
     # Signalize that the upgrade correctly ended
     echo "12.3" >> $UPGRADEDIR/admin-server-upgraded-ok
 
+    # epmd needs to listen on all interfaces for rabbit to be able to ask for a port
+    # this file will get overwritten by the crowbar cookbook afterwards to listen only in the
+    # listen address of rabbit
+    mkdir -p /etc/systemd/system/epmd.socket.d/
+    touch /etc/systemd/system/epmd.socket.d/ports.conf
+    cat >/etc/systemd/system/epmd.socket.d/ports.conf <<EOF
+[Socket]
+# unset all ports defined in the global file, in our case this is 127.0.0.1:4369
+ListenStream=
+# add our new ports
+ListenStream=[::]:4369
+FreeBind=true
+EOF
+
     # On Cloud7, crowbar-init bootstraps crowbar
     systemctl disable crowbar
     systemctl enable crowbar-init


### PR DESCRIPTION
After the package upgrade for epmd it will only listen on
127.0.0.1 which will prevent rabbitmq-server for working, as
it will try to obtain a port on all interfaces by asking epmd
on the appropiate interface but will fail to do so on any interface
other than 127.0.0.1

With this we patch epmd to listen on all interfaces after the upgrade
so it will be ready for when rabbit comes up. The systemd override will
get afterwards be set to listen only in the proper interface as soon as
the crowbar cookbook is run on the admin node.


Note: This is only needed in 7 -> 8 upgrade, should not be needed in the future