### PR TITLE
[4.0] upgrade: Make sure schemas are properly migrated after the upgrade

### DIFF
--- a/scripts/upgrade_admin_server.sh
+++ b/scripts/upgrade_admin_server.sh
@@ -119,6 +119,11 @@ ListenStream=[::]:4369
 FreeBind=true
 EOF
 
+    # Make sure to do schema migration properly after packages were upgraded
+    pushd /opt/dell/crowbar_framework
+    sudo -u crowbar RAILS_ENV=production bin/rake crowbar:schema_migrate_prod
+    popd
+
     # cleanup upgrading indication
     # technically the upgrade is not done yet but it has to be
     # done before the reboot


### PR DESCRIPTION
This used to be one of the tasks of crowbar-init (after it would
set up new database), but because we do not need new database,
we've dropped crowbar-init usage completely.