### PR TITLE
[4.0] upgrade: Lock crowbar-ui before admin upgrade

### DIFF
--- a/scripts/upgrade_admin_server.sh
+++ b/scripts/upgrade_admin_server.sh
@@ -78,6 +78,12 @@ upgrade_admin_server()
 
     trap cleanup INT EXIT
 
+    # Lock crowbar-ui package until upgrade is finished.
+    # During N->N+1 upgrade, version from N will handle whole upgrade process.
+    # With this lock, older version of crowbar-ui package will be kept while
+    # the rest of packages are upgraded.
+    zypper addlock 'crowbar-ui*'
+
     ### Chef-client could lockj zypper and break upgrade
     rcchef-client stop
 


### PR DESCRIPTION
As crowbar-ui from CloudN will be used to handle N->N+1 upgrade,
we need to lock the package so it's not upgraded with the rest of
admin server.