### PR TITLE
[3.0] upgrade: Lock crowbar-ui before admin upgrade

### DIFF
--- a/scripts/upgrade_admin_server.sh
+++ b/scripts/upgrade_admin_server.sh
@@ -72,6 +72,12 @@ upgrade_admin_server()
 
     trap cleanup INT EXIT
 
+    # Lock crowbar-ui package until upgrade is finished.
+    # During N->N+1 upgrade, version from N will handle whole upgrade process.
+    # With this lock, older version of crowbar-ui package will be kept while
+    # the rest of packages are upgraded.
+    zypper addlock 'crowbar-ui*'
+
     # we will need the dump for later migrating it into postgresql
     pushd /opt/dell/crowbar_framework
     sudo -u crowbar RAILS_ENV=production bin/rake db:migrate


### PR DESCRIPTION
As crowbar-ui from CloudN will be used to handle N->N+1 upgrade,
we need to lock the package so it's not upgraded with the rest of
admin server.

(cherry picked from commit b3ee5a17e81ea238fd113315a58f1d1950ca7af3)

backport of #2350 