### PR TITLE
crowbar: Skip creation of SLES 12.3 PTF repositories

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -577,11 +577,9 @@ fi
 
 for arch in $supported_arches; do
     check_or_create_ptf_repository 12.4 $arch PTF
-    check_or_create_ptf_repository 12.3 $arch PTF
 
     # Currently we only sign the PTF repository
     sign_repositories 12.4 $arch PTF
-    sign_repositories 12.3 $arch PTF
 done
 
 # Setup helper for git


### PR DESCRIPTION
Those shouldn't be necessary anymore, so we can skip that effort.