### PR TITLE
Add support for 40GbE and 56GbE network interface(bsc#1108336)

### DIFF
--- a/scripts/network-json-validator
+++ b/scripts/network-json-validator
@@ -100,7 +100,7 @@ class CrowbarConduit
 
     @if_list.each do |iface|
       m = /^([-+?]?)(\d{1,3}[mg])(\d+)$/.match(iface) # [1]=sign, [2]=speed, [3]=count
-      if m.nil? || !%w{10m 100m 1g 10g}.include?(m[2])
+      if m.nil? || !%w{10m 100m 1g 10g 20g 40g 56g}.include?(m[2])
         raise "invalid interface '#{iface}' in conduit '#{@name}'"
       end
     end


### PR DESCRIPTION
Without this the network-json-validator fails for these interfaces.