### PR TITLE
Add IPv6 support to a few scripts

### DIFF
--- a/scripts/network-json-validator
+++ b/scripts/network-json-validator
@@ -207,8 +207,13 @@ class CrowbarNetwork
     @conduit = json['conduit']
 
     @subnet_addr = IPAddr.new(@subnet)
+    cidr_to_netmask
     @netmask_addr = IPAddr.new(@netmask)
-    @broadcast_addr = IPAddr.new(@broadcast)
+    if @subnet_addr.ipv4?
+        @broadcast_addr = IPAddr.new(@broadcast)
+    else
+        @broadcast_addr = nil
+    end
     @router_addr = nil
     @router_addr = IPAddr.new(@router) unless @router.nil?
 
@@ -229,6 +234,27 @@ class CrowbarNetwork
     end
   end
 
+  def cidr_to_netmask
+    if @subnet_addr.ipv6?
+      range = 128
+    else
+      range = 32
+    end
+
+    cidr = Integer(@netmask) rescue nil
+    if cidr && !(1..range).cover?(cidr)
+      raise "invalid CIDR netmask '#{cidr}' > '#{range}'"
+    end
+
+    if cidr
+      if @subnet_addr.ipv6?
+        @netmask = IPAddr.new('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff').mask(cidr).to_s
+      else
+        @netmask = IPAddr.new('255.255.255.255').mask(cidr).to_s
+      end
+    end
+  end
+
   def validate
     netmask_bits = @netmask_addr.to_i.to_s(2).count("1")
 
@@ -245,8 +271,10 @@ class CrowbarNetwork
       raise "invalid subnet '#{@subnet}' for netmask '#{@netmask}'"
     end
 
-    if @broadcast_addr != @subnet_addr|~@netmask_addr
-      raise "invalid broadcast '#{@broadcast}' for subnet '#{@subnet}/#{@netmask}' (should be '#{(@subnet_addr|~@netmask_addr).to_s}')"
+    if @subnet_addr.ipv4?
+      if @broadcast_addr != @subnet_addr|~@netmask_addr
+        raise "invalid broadcast '#{@broadcast}' for subnet '#{@subnet}/#{@netmask}' (should be '#{(@subnet_addr|~@netmask_addr).to_s}')"
+      end
     end
 
     unless @router.nil?
@@ -434,7 +462,7 @@ def validate_networks databag
 
   @networks.each do |namea, neta|
     @networks.each do |nameb, netb|
-      unless namea == nameb
+      unless namea == nameb || neta.subnet_addr.ipv6? || netb.subnet_addr.ipv6?
         no_conflicting_ranges(neta, netb)
       end
     end


### PR DESCRIPTION
Add IPv6 support to a network-json-validator and install-chef-suse.sh
    
This patch add IPv6 support to network-json-validator and the
install-chef-suse.sh scripts as required to run an IPv6 CP.

The network-json-validator tool now supports sending the netmask in
in cidr from, eg 32 or 64 etc. And also supports all the IPs elements
as ipv6 addresses.

If the netmask is a CIDR then it also makes sure the value is a valid
integer value for the IP address type:

  IPv4 - 1-32
  IPv6 - 1-128

It determine's the IP type based of the subnet address.

CIDR's are then converted to the full netmask representation
so it can get all the normal netmask checks.

The install-chef-suse.sh script likewise supports the admin ip being
ipv6 and will also wrap the IP in '[]' when required.
As well as making sure that when using IPv6 the chef-sever listens
for IPv6 connections by listening on [::].

If the admin ip is an ipv6 address this patch will place an
/etc/sysconfig/chef-server file (as the systemd service expects)
to provide other options, in our case it adds:

  OPTIONS="-h ::"