### PR TITLE
Ignore violations of jshint in vendor dir (SCRD-7470)

### DIFF
--- a/.hound.jshint.yml
+++ b/.hound.jshint.yml
@@ -1,0 +1,2 @@
+ignore_file: .jshint_ignore
+

--- a/.hound.yml
+++ b/.hound.yml
@@ -7,4 +7,7 @@ haml:
 scss:
   config_file: .hound.scss.yml
 
+jshint:
+  config_file: .hound.jshint.yml
+
 fail_on_violations: true

--- a/.jshint_ignore
+++ b/.jshint_ignore
@@ -1,0 +1,1 @@
+crowbar_framework/vendor/**/*


### PR DESCRIPTION
Hound runs jshint by default on all files in a repo. In `crowbar-core` we don't want to run this on the vendor files. There already exists a similar rule for the `scss` linter.

Needed for crowbar/crowbar-core#1797