### PR TITLE
[4.0] install-chef-suse: filter comments from authorized_keys file

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -909,8 +909,8 @@ $json_edit "$CROWBAR_JSON" -n \
 
 # Use existing SSH authorized keys
 if [ -f /root/.ssh/authorized_keys ]; then
-    # remove empty lines and change newline to \n
-    access_keys=$(sed "/^ *$/d" /root/.ssh/authorized_keys | sed "N;s/\n/\\n/g")
+    # remove empty lines and comments and change newline to \n
+    access_keys=$(sed "/^ *$/d;/^ *#/d" /root/.ssh/authorized_keys | sed "N;s/\n/\\n/g")
     provisioner_keys=$(json_read "$PROVISIONER_JSON" \
         attributes.provisioner.access_keys)
     if [ ! -f "$PROVISIONER_JSON" -o -z "$provisioner_keys" ]


### PR DESCRIPTION
If the authorized_keys file on the admin node has comments the installation fails. Ceph is complaining about the comments not being valid ssh keys.

This fix filters out the comments when reading the keys.

Backport of d1b19dc1a0797f9c33dc254933279b42ac69fbe8

See also: https://github.com/crowbar/crowbar/pull/2371