### PR TITLE
Make bundle install work with ruby-2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ source "https://rubygems.org"
 
 group :development do
   gem "rake", ">= 10.3"
-  gem "rb-inotify", ">= 0.9"
+  gem "rb-inotify", "~> 0.9.0"
   # use older version of listen (dependency of guard)
   # ~> 3.1.0 requires ruby 2.2
   gem "listen", "~> 3.0.7"
@@ -29,6 +29,8 @@ group :development do
   gem "git", ">= 1.2"
   gem "netrc", ">= 0.10"
   gem "deep_merge", ">= 1.0"
-  gem "rubocop", "~> 0.48"
+  gem "parallel", "~> 1.13.0"
+  gem "psych", "~> 2.0"
+  gem "rubocop", "~> 0.56.0"
   gem "rubocop-git", "~> 0.1"
 end


### PR DESCRIPTION
Make bundle install work with ruby-2.1
because that is what we have in SLE-12-SP4

This should unbreak
https://ci.suse.de/job/cloud-mkcloud9-job-crowbar-devsetup-x86_64/
https://ci.suse.de/job/cloud-mkcloud8-job-crowbar-devsetup-x86_64/
that might have been red for 15 months