### PR TITLE
crowbar: Relax conditional for aborting installation

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -344,19 +344,28 @@ EOF
     exit 1
 fi
 
-if ! (systemctl -q is-active crowbar-init.service && reset_crowbar ); then
-
-    cat <<EOF | pipe_show_and_log
+if ! (reset_crowbar 2> /dev/null); then
+    if systemctl --quiet is-active crowbar-init.service; then
+        cat <<EOF | pipe_show_and_log
 Aborting: Can not initialize Crowbar database
 
-Prior running the installation script, please execute at least
+Prior to running the installation script, please execute at least
+(c.f. Chapter 8 of the Deployment Guide):
 
   systemctl start crowbar-init.service
   crowbarctl database create
 
-If you configured an external database,
-there might be an error connecting.
+If you have configured an external database, there might be an error
+connecting.
 EOF
+    else
+        cat <<EOF | pipe_show_and_log
+Aborting: Cannot initialize Crowbar database
+
+If you have configured an external database, there might be an error
+connecting.
+EOF
+    fi
     exit 1
 fi
 


### PR DESCRIPTION
[SCRD-8330] The `install-chef-suse.sh` script is not only called during initial deployment, but also during a Crowbar restore operation. At restore time, the `crowbar-init.service` might not be running anymore and the current conditional testing for whether the installation can continue is too strict in this case. This change relaxes the conditional by unconditionally running the `reset_crowbar` step, while intercepting a
potential failure.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.de>