### PR TITLE
 install-chef-suse: Do not depend on machine-install user

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -1027,14 +1027,9 @@ if [ "$($CROWBAR crowbar proposal list)" != "default" ] ; then
     fi
 fi
 
-# this has machine key world readable? care?
-$CROWBAR crowbar proposal show default >/var/log/crowbar/default-proposal.json
-
 # next will fail if ntp barclamp not present (or did for me...)
 $CROWBAR crowbar proposal commit default || \
     die "Could not commit default proposal!"
-
-$CROWBAR crowbar proposal show default >/var/log/crowbar/default.json
 
 crowbar_up=true
 $chef_client


### PR DESCRIPTION
With the goal of removing the machine-install in mind, this commit moves
install-chef-suse to:

  - create a /etc/crowbarrc file
  - use crowbarctl instead of crowbar CLI

Note that the "crowbarctl proposal show" call needs --raw, as otherwise
crowbarctl tries to be clever, but fetches the list of clusters -- which
is not possible during the install process (that API is not up yet).

We still create the machine-install user as other bits in Crowbar still
depend on it, but we'll eventually remove it.

Note: this depends on https://github.com/crowbar/crowbar-client/pull/188