### PR TITLE
Fix ignoring of jshint violations in vendors dir

### DIFF
--- a/.hound.jshint.yml
+++ b/.hound.jshint.yml
@@ -1,2 +1,0 @@
-ignore_file: .jshint_ignore
-

--- a/.hound.yml
+++ b/.hound.yml
@@ -8,6 +8,6 @@ scss:
   config_file: .hound.scss.yml
 
 jshint:
-  config_file: .hound.jshint.yml
+  ignore_file: .jshint_ignore
 
 fail_on_violations: true


### PR DESCRIPTION
Previous version was not fully correct and Hound didn't like it.

See: https://help.houndci.com/configuration/jshint