### PR TITLE
crowbar: Make potential output of reset_crowbar visible

### DIFF
--- a/scripts/install-chef-suse.sh
+++ b/scripts/install-chef-suse.sh
@@ -344,7 +344,7 @@ EOF
     exit 1
 fi
 
-if ! (reset_crowbar 2> /dev/null); then
+if ! reset_crowbar; then
     if systemctl --quiet is-active crowbar-init.service; then
         cat <<EOF | pipe_show_and_log
 Aborting: Can not initialize Crowbar database


### PR DESCRIPTION
This change makes potential output from `reset_crowbar` visible since
it might be useful for the user to understand what went wrong in case
something went wrong.